### PR TITLE
CI: skip TimeCritical/Integration tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,8 @@ jobs:
           fi
 
       - name: Test with coverage
-        run: dotnet test -c Release --no-build --verbosity normal --collect:"XPlat Code Coverage" --results-directory ./coverage
+        # Skip Integration (needs Mongo/Redis) and TimeCritical (wall-clock asserts) tests on shared CI runners.
+        run: dotnet test -c Release --no-build --verbosity normal --filter "(Category!=Integration)&(Category!=TimeCritical)" --collect:"XPlat Code Coverage" --results-directory ./coverage
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5


### PR DESCRIPTION
## Summary

The previous merge to master (PR #39) failed its post-merge CI run on two known wall-clock-flaky tests: `FetchDataThrottleTests.ManyParallelCallsAreQueued` and `ManyParallelCallsAreQueuedForDifferentTypes`. Both are decorated with `[Trait(\"Category\", \"TimeCritical\")]` and were filtered out of the legacy Azure DevOps pipeline, but the new GitHub Actions workflow runs everything.

This PR restores the legacy test filter on the workflow's `Test with coverage` step:

```
--filter "(Category!=Integration)&(Category!=TimeCritical)"
```

- **Integration** category — needs live Mongo/Redis (the existing tests are commented-out fixtures).
- **TimeCritical** category — `FetchQueue` throttling tests assert wall-clock parallelism timing (e.g. \"elapsed < 200ms\"). Useful when run on a quiet developer machine; unreliable on shared GitHub-hosted runners.

Both categories remain runnable locally (no filter applied for `dotnet test` invocations from a developer shell).

## Test plan
- [ ] CI build runs only the deterministic test set on this PR.
- [ ] Master push CI is green after merge.