### PR TITLE
chore: bump NuGet packages

### DIFF
--- a/Sample/Tharga.Cache.Console/Tharga.Cache.Console.csproj
+++ b/Sample/Tharga.Cache.Console/Tharga.Cache.Console.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Tharga.Console" Version="3.7.4" />
+		<PackageReference Include="Tharga.Console" Version="4.1.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Tharga.Cache.Blazor/Tharga.Cache.Blazor.csproj
+++ b/Tharga.Cache.Blazor/Tharga.Cache.Blazor.csproj
@@ -27,7 +27,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Tharga.Blazor" Version="2.1.5" />
+    <PackageReference Include="Tharga.Blazor" Version="2.1.6" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Tharga.Cache\Tharga.Cache.csproj" />

--- a/Tharga.Cache.File.Tests/Tharga.Cache.File.Tests.csproj
+++ b/Tharga.Cache.File.Tests/Tharga.Cache.File.Tests.csproj
@@ -6,19 +6,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="8.9.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
+    <PackageReference Include="FluentAssertions" Version="8.10.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="10.0.0">
+    <PackageReference Include="coverlet.msbuild" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Tharga.Cache.File/Tharga.Cache.File.csproj
+++ b/Tharga.Cache.File/Tharga.Cache.File.csproj
@@ -35,7 +35,7 @@
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.203">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Tharga.Cache.Mcp/Tharga.Cache.Mcp.csproj
+++ b/Tharga.Cache.Mcp/Tharga.Cache.Mcp.csproj
@@ -33,8 +33,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Tharga.Mcp" Version="0.1.3" />
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.203">
+		<PackageReference Include="Tharga.Mcp" Version="0.1.4" />
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/Tharga.Cache.MongoDB.Tests/Tharga.Cache.MongoDB.Tests.csproj
+++ b/Tharga.Cache.MongoDB.Tests/Tharga.Cache.MongoDB.Tests.csproj
@@ -6,19 +6,19 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="FluentAssertions" Version="8.9.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
+		<PackageReference Include="FluentAssertions" Version="8.10.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.msbuild" Version="10.0.0">
+		<PackageReference Include="coverlet.msbuild" Version="10.0.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="10.0.0">
+		<PackageReference Include="coverlet.collector" Version="10.0.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/Tharga.Cache.MongoDB/Tharga.Cache.MongoDB.csproj
+++ b/Tharga.Cache.MongoDB/Tharga.Cache.MongoDB.csproj
@@ -35,11 +35,11 @@
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.203">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Tharga.MongoDB" Version="2.10.10" />
+    <PackageReference Include="Tharga.MongoDB" Version="2.10.12" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Tharga.Cache\Tharga.Cache.csproj" />

--- a/Tharga.Cache.Redis.Tests/Tharga.Cache.Redis.Tests.csproj
+++ b/Tharga.Cache.Redis.Tests/Tharga.Cache.Redis.Tests.csproj
@@ -8,19 +8,19 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="FluentAssertions" Version="8.9.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
+		<PackageReference Include="FluentAssertions" Version="8.10.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.msbuild" Version="10.0.0">
+		<PackageReference Include="coverlet.msbuild" Version="10.0.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="10.0.0">
+		<PackageReference Include="coverlet.collector" Version="10.0.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/Tharga.Cache.Redis/Tharga.Cache.Redis.csproj
+++ b/Tharga.Cache.Redis/Tharga.Cache.Redis.csproj
@@ -41,8 +41,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Polly" Version="8.6.6" />
-		<PackageReference Include="StackExchange.Redis" Version="2.12.14" />
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.203">
+		<PackageReference Include="StackExchange.Redis" Version="2.13.1" />
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/Tharga.Cache.Tests/Tharga.Cache.Tests.csproj
+++ b/Tharga.Cache.Tests/Tharga.Cache.Tests.csproj
@@ -8,19 +8,19 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="FluentAssertions" Version="8.9.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
+		<PackageReference Include="FluentAssertions" Version="8.10.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.msbuild" Version="10.0.0">
+		<PackageReference Include="coverlet.msbuild" Version="10.0.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="10.0.0">
+		<PackageReference Include="coverlet.collector" Version="10.0.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/Tharga.Cache/Tharga.Cache.csproj
+++ b/Tharga.Cache/Tharga.Cache.csproj
@@ -42,9 +42,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="FluentAssertions" Version="8.9.0" />
-		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.203">
+		<PackageReference Include="FluentAssertions" Version="8.10.0" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>


### PR DESCRIPTION
## Summary
- Bumps all outdated NuGet packages across the solution.
- Includes one major version bump: **Tharga.Console 3.7.4 → 4.1.1** (sample only); the Console sample builds clean on 4.1.1.

## Bumped versions
| Package | From | To |
|---|---|---|
| FluentAssertions | 8.9.0 | 8.10.0 |
| Microsoft.Extensions.Hosting.Abstractions | 10.0.7 | 10.0.8 |
| Microsoft.SourceLink.GitHub | 10.0.203 | 10.0.300 |
| Microsoft.AspNetCore.Mvc.Testing | 10.0.7 | 10.0.8 |
| coverlet.collector / coverlet.msbuild | 10.0.0 | 10.0.1 |
| Tharga.MongoDB | 2.10.10 | 2.10.12 |
| StackExchange.Redis | 2.12.14 | 2.13.1 |
| Tharga.Blazor | 2.1.5 | 2.1.6 |
| Tharga.Mcp | 0.1.3 | 0.1.4 |
| Tharga.Console (sample) | 3.7.4 | 4.1.1 |

## Test plan
- [x] `dotnet build` — succeeds with 0 errors (1 pre-existing unrelated CS0162 warning in `Tharga.Cache.File/File.cs:63`).
- [ ] CI green
- [ ] Quick smoke of the Console sample on Tharga.Console 4.x