### PR TITLE
Fail-open cache when persist backend is unreachable (#50)

### DIFF
--- a/Tharga.Cache.Redis.Tests/RedisResiliencePolicyTests.cs
+++ b/Tharga.Cache.Redis.Tests/RedisResiliencePolicyTests.cs
@@ -1,0 +1,78 @@
+using FluentAssertions;
+using Polly;
+using Polly.CircuitBreaker;
+using Xunit;
+
+namespace Tharga.Cache.Redis.Tests;
+
+public class RedisResiliencePolicyTests
+{
+    [Fact]
+    public async Task Circuit_opens_after_threshold_and_then_fails_fast_without_invoking_backend()
+    {
+        //Arrange — no retry so the breaker trips deterministically after exactly `threshold` failures.
+        var options = new RedisCacheOptions
+        {
+            RetryCount = 0,
+            CircuitBreakerFailureThreshold = 2,
+            CircuitBreakerDuration = TimeSpan.FromMinutes(1)
+        };
+        var policy = RedisResiliencePolicy.Create(options, null);
+
+        var invocations = 0;
+        Func<Task> failing = async () =>
+        {
+            invocations++;
+            await Task.Yield();
+            throw new TimeoutException("simulated outage");
+        };
+
+        //Act — trip the breaker.
+        for (var i = 0; i < options.CircuitBreakerFailureThreshold; i++)
+        {
+            await policy.Invoking(p => p.ExecuteAsync(failing)).Should().ThrowAsync<TimeoutException>();
+        }
+
+        var invocationsBeforeOpen = invocations;
+
+        //Assert — the circuit is now open: the next call fails fast without touching the backend.
+        await policy.Invoking(p => p.ExecuteAsync(failing)).Should().ThrowAsync<BrokenCircuitException>();
+        invocations.Should().Be(invocationsBeforeOpen, "an open circuit must short-circuit instead of invoking the backend");
+    }
+
+    [Fact]
+    public async Task Successful_call_passes_through()
+    {
+        //Arrange
+        var policy = RedisResiliencePolicy.Create(new RedisCacheOptions { RetryCount = 0, CircuitBreakerFailureThreshold = 5 }, null);
+
+        //Act
+        var result = await policy.ExecuteAsync(() => Task.FromResult(42));
+
+        //Assert
+        result.Should().Be(42);
+    }
+
+    [Fact]
+    public async Task Retries_transient_failures_then_succeeds()
+    {
+        //Arrange
+        var options = new RedisCacheOptions { RetryCount = 2, CircuitBreakerFailureThreshold = 5 };
+        var policy = RedisResiliencePolicy.Create(options, null);
+
+        var attempts = 0;
+
+        //Act
+        var result = await policy.ExecuteAsync(async () =>
+        {
+            attempts++;
+            await Task.Yield();
+            if (attempts < 3) throw new TimeoutException("transient");
+            return "ok";
+        });
+
+        //Assert
+        result.Should().Be("ok");
+        attempts.Should().Be(3, "the call should be retried twice before succeeding on the third attempt");
+    }
+}

--- a/Tharga.Cache.Redis/README.md
+++ b/Tharga.Cache.Redis/README.md
@@ -31,6 +31,28 @@ Any type registered with `IRedis` is persisted to Redis. Unregistered types defa
 - **Survives restarts** — cached data is not lost on deploy
 - **High throughput** with low latency
 
+## Resilience (fail-open)
+
+If Redis becomes unreachable, the cache **fails open**: a backend read error is treated as a miss so the
+call falls through to your source loader, and a backend write error is swallowed. A cache outage therefore
+never faults the caller as long as the source of truth is healthy. This is on by default and can be turned
+off with `CacheOptions.FailOpenOnBackendError = false` (which restores the previous throwing behavior).
+
+A Polly **circuit breaker** sits in front of the Redis connection so a sustained outage short-circuits
+immediately instead of paying retry latency on every call (which is what prevents thread-pool starvation).
+The breaker recovers automatically once Redis is healthy again.
+
+```csharp
+o.AddRedisDBOptions(r =>
+{
+    r.ConnectionStringLoader = sp => "localhost:6379";
+    r.RetryCount = 3;                                     // transient-error retries before a call fails (default 3)
+    r.CircuitBreakerFailureThreshold = 5;                 // consecutive failures before the circuit opens (default 5)
+    r.CircuitBreakerDuration = TimeSpan.FromSeconds(30);  // how long it stays open before probing again (default 30s)
+    r.CommandTimeout = TimeSpan.FromSeconds(1);           // optional shorter per-command timeout for fast fail-open
+});
+```
+
 ## Documentation
 
 Full documentation, configuration options, and samples are available on the [GitHub project page](https://github.com/Tharga/Cache).

--- a/Tharga.Cache.Redis/Redis.cs
+++ b/Tharga.Cache.Redis/Redis.cs
@@ -1,11 +1,10 @@
 ﻿using System.Diagnostics;
-using System.Net.Sockets;
 using System.Text.Json;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Polly;
-using Polly.Retry;
+using Polly.CircuitBreaker;
 using StackExchange.Redis;
 using Tharga.Cache.Core;
 
@@ -17,7 +16,7 @@ internal class Redis : IRedis
     private readonly IHostEnvironment _hostEnvironment;
     private readonly RedisCacheOptions _options;
     private readonly ILogger<Redis> _logger;
-    private readonly AsyncRetryPolicy _retryPolicy;
+    private readonly IAsyncPolicy _resiliencePolicy;
     private ConnectionMultiplexer _redisConnection;
 
     public Redis(IServiceProvider serviceProvider, IHostEnvironment hostEnvironment, IManagedCacheMonitor cacheMonitor, IOptions<RedisCacheOptions> options, ILogger<Redis> logger)
@@ -26,14 +25,7 @@ internal class Redis : IRedis
         _hostEnvironment = hostEnvironment;
         _options = options.Value;
         _logger = logger;
-        _retryPolicy = Policy
-            .Handle<RedisException>()
-            .Or<TimeoutException>()
-            .Or<SocketException>()
-            .WaitAndRetryAsync(
-                3,
-                attempt => TimeSpan.FromMilliseconds(200 * Math.Pow(2, attempt)),
-                (exception, timeSpan, retryCount, _) => { _logger.LogWarning($"Retry {retryCount} after {timeSpan.TotalMilliseconds}ms due to: {exception.Message}"); });
+        _resiliencePolicy = RedisResiliencePolicy.Create(_options, logger);
 
         cacheMonitor.RequestEvictEvent += async (_, e) =>
         {
@@ -50,7 +42,7 @@ internal class Redis : IRedis
 
     public async Task<CacheItem<T>> GetAsync<T>(Key key)
     {
-        return await _retryPolicy.ExecuteAsync(async () =>
+        return await _resiliencePolicy.ExecuteAsync(async () =>
         {
             var redisConnection = await GetConnection();
             if (redisConnection.Multiplexer == null) return null;
@@ -74,7 +66,7 @@ internal class Redis : IRedis
 
     public async Task SetAsync<T>(Key key, CacheItem<T> cacheItem, bool staleWhileRevalidate)
     {
-        await _retryPolicy.ExecuteAsync(async () =>
+        await _resiliencePolicy.ExecuteAsync(async () =>
         {
             var item = JsonSerializer.Serialize(cacheItem);
             if (Debugger.IsAttached)
@@ -101,17 +93,17 @@ internal class Redis : IRedis
 
     public async Task<bool> BuyMoreTime<T>(Key key)
     {
-        return await _retryPolicy.ExecuteAsync(async () => await SetUpdateTime<T>(key, DateTime.UtcNow));
+        return await _resiliencePolicy.ExecuteAsync(async () => await SetUpdateTime<T>(key, DateTime.UtcNow));
     }
 
     public async Task<bool> Invalidate<T>(Key key)
     {
-        return await _retryPolicy.ExecuteAsync(async () => await SetUpdateTime<T>(key, DateTime.MinValue));
+        return await _resiliencePolicy.ExecuteAsync(async () => await SetUpdateTime<T>(key, DateTime.MinValue));
     }
 
     public async Task<bool> DropAsync<T>(Key key)
     {
-        return await _retryPolicy.ExecuteAsync(async () =>
+        return await _resiliencePolicy.ExecuteAsync(async () =>
         {
             var redisConnection = await GetConnection();
             if (redisConnection.Multiplexer == null) return false;
@@ -124,13 +116,20 @@ internal class Redis : IRedis
 
     public async Task<(bool Success, string Message)> CanConnectAsync()
     {
-        return await _retryPolicy.ExecuteAsync(async () =>
+        try
         {
-            var redisConnection = await GetConnection();
-            if (redisConnection.Multiplexer == null) return (false, redisConnection.Message);
+            return await _resiliencePolicy.ExecuteAsync(async () =>
+            {
+                var redisConnection = await GetConnection();
+                if (redisConnection.Multiplexer == null) return (false, redisConnection.Message);
 
-            return (redisConnection.Multiplexer.IsConnected, redisConnection.Message);
-        });
+                return (redisConnection.Multiplexer.IsConnected, redisConnection.Message);
+            });
+        }
+        catch (BrokenCircuitException e)
+        {
+            return (false, $"Redis circuit is open: {e.Message}");
+        }
     }
 
     private async Task<bool> SetUpdateTime<T>(Key key, DateTime updateTime)
@@ -174,7 +173,20 @@ internal class Redis : IRedis
 
         try
         {
-            _redisConnection = await ConnectionMultiplexer.ConnectAsync(connectionString);
+            if (_options.CommandTimeout is { } commandTimeout)
+            {
+                var config = ConfigurationOptions.Parse(connectionString);
+                var milliseconds = (int)commandTimeout.TotalMilliseconds;
+                config.AsyncTimeout = milliseconds;
+                config.SyncTimeout = milliseconds;
+                config.ConnectTimeout = milliseconds;
+                _redisConnection = await ConnectionMultiplexer.ConnectAsync(config);
+            }
+            else
+            {
+                _redisConnection = await ConnectionMultiplexer.ConnectAsync(connectionString);
+            }
+
             return (_redisConnection, "Connected to Redis.");
         }
         catch (Exception e)

--- a/Tharga.Cache.Redis/RedisCacheOptions.cs
+++ b/Tharga.Cache.Redis/RedisCacheOptions.cs
@@ -1,6 +1,33 @@
-﻿namespace Tharga.Cache.Redis;
+namespace Tharga.Cache.Redis;
 
 public record RedisCacheOptions
 {
     public Func<IServiceProvider, string> ConnectionStringLoader;
+
+    /// <summary>
+    /// Number of retry attempts on a transient Redis error before a call is considered failed. Default 3.
+    /// Set to 0 to disable retries (each call is attempted once).
+    /// </summary>
+    public int RetryCount { get; set; } = 3;
+
+    /// <summary>
+    /// Number of consecutive failed calls before the circuit opens and subsequent calls fail fast
+    /// (throwing <see cref="Polly.CircuitBreaker.BrokenCircuitException"/>) instead of paying retry latency.
+    /// Combined with <see cref="Tharga.Cache.CacheOptions.FailOpenOnBackendError"/>, an open circuit means the
+    /// cache falls straight through to the source loader. Default 5.
+    /// </summary>
+    public int CircuitBreakerFailureThreshold { get; set; } = 5;
+
+    /// <summary>
+    /// How long the circuit stays open before it transitions to half-open and probes the backend with a
+    /// single trial call. Default 30 seconds.
+    /// </summary>
+    public TimeSpan CircuitBreakerDuration { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Optional per-command timeout applied to the StackExchange.Redis connection
+    /// (Async / Sync / Connect timeout). A shorter timeout makes the fail-open path fast even before the
+    /// circuit breaker opens. When null, the connection-string / library defaults apply.
+    /// </summary>
+    public TimeSpan? CommandTimeout { get; set; }
 }

--- a/Tharga.Cache.Redis/RedisResiliencePolicy.cs
+++ b/Tharga.Cache.Redis/RedisResiliencePolicy.cs
@@ -1,0 +1,42 @@
+using System.Net.Sockets;
+using Microsoft.Extensions.Logging;
+using Polly;
+using StackExchange.Redis;
+
+namespace Tharga.Cache.Redis;
+
+/// <summary>
+/// Builds the resilience pipeline used by the Redis persist backend: a retry policy wrapped by a circuit breaker.
+/// The breaker is the outer policy, so once it is open calls fail fast (<see cref="Polly.CircuitBreaker.BrokenCircuitException"/>)
+/// without paying any retry latency — which is what prevents a sustained outage from starving the thread pool.
+/// </summary>
+internal static class RedisResiliencePolicy
+{
+    internal static IAsyncPolicy Create(RedisCacheOptions options, ILogger logger)
+    {
+        var retryCount = Math.Max(0, options.RetryCount);
+        var retryPolicy = Policy
+            .Handle<RedisException>()
+            .Or<TimeoutException>()
+            .Or<SocketException>()
+            .WaitAndRetryAsync(
+                retryCount,
+                attempt => TimeSpan.FromMilliseconds(200 * Math.Pow(2, attempt)),
+                (exception, timeSpan, retryCount, _) => logger?.LogWarning("Redis retry {RetryCount} after {Delay}ms due to: {Message}", retryCount, timeSpan.TotalMilliseconds, exception.Message));
+
+        var threshold = Math.Max(1, options.CircuitBreakerFailureThreshold);
+        var circuitBreakerPolicy = Policy
+            .Handle<RedisException>()
+            .Or<TimeoutException>()
+            .Or<SocketException>()
+            .CircuitBreakerAsync(
+                threshold,
+                options.CircuitBreakerDuration,
+                onBreak: (exception, breakDelay) => logger?.LogWarning("Redis circuit opened for {Delay}ms after {Threshold} consecutive failures: {Message}", breakDelay.TotalMilliseconds, threshold, exception.Message),
+                onReset: () => logger?.LogInformation("Redis circuit reset; calls are flowing to the backend again."),
+                onHalfOpen: () => logger?.LogInformation("Redis circuit half-open; probing the backend with a trial call."));
+
+        // Breaker (outer) wraps retry (inner): when the breaker is open, the retry never runs.
+        return Policy.WrapAsync(circuitBreakerPolicy, retryPolicy);
+    }
+}

--- a/Tharga.Cache.Tests/FailOpenTests.cs
+++ b/Tharga.Cache.Tests/FailOpenTests.cs
@@ -1,0 +1,129 @@
+using FluentAssertions;
+using Moq;
+using Tharga.Cache.Core;
+using Tharga.Cache.Persist;
+using Xunit;
+
+namespace Tharga.Cache.Tests;
+
+public class FailOpenTests
+{
+    [Fact]
+    public async Task GetAsync_returns_source_loader_result_when_backend_read_throws()
+    {
+        //Arrange
+        var (sut, persist) = BuildCache(failOpen: true);
+
+        //Act
+        var result = await sut.GetAsync("Key", () => Task.FromResult("from-source"));
+
+        //Assert
+        result.Should().Be("from-source", "a backend read failure should fail open to the source loader");
+        persist.GetCalls.Should().BeGreaterThan(0, "the backend should have been attempted before failing open");
+    }
+
+    [Fact]
+    public async Task GetAsync_does_not_fault_when_backend_write_throws()
+    {
+        //Arrange — read fails open to the loader, then the write-back to the backend also throws.
+        var (sut, persist) = BuildCache(failOpen: true);
+
+        //Act
+        var result = await sut.GetAsync("Key", () => Task.FromResult("from-source"));
+
+        //Assert
+        result.Should().Be("from-source", "a failed cache write must not fault the caller");
+        persist.SetCalls.Should().BeGreaterThan(0, "the write-back should have been attempted");
+    }
+
+    [Fact]
+    public async Task SetAsync_does_not_fault_when_backend_write_throws()
+    {
+        //Arrange
+        var (sut, persist) = BuildCache(failOpen: true);
+
+        //Act
+        var act = async () => await sut.SetAsync("Key", "value");
+
+        //Assert
+        await act.Should().NotThrowAsync("an explicit SetAsync must not fault when the backend write fails");
+        persist.SetCalls.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task GetAsync_rethrows_when_FailOpenOnBackendError_is_disabled()
+    {
+        //Arrange
+        var (sut, _) = BuildCache(failOpen: false);
+
+        //Act
+        var act = async () => await sut.GetAsync("Key", () => Task.FromResult("from-source"));
+
+        //Assert
+        await act.Should().ThrowAsync<TimeoutException>("fail-open is opt-out; disabling it preserves the throwing behavior");
+    }
+
+    private static (ICache Cache, ThrowingPersist Persist) BuildCache(bool failOpen)
+    {
+        var options = new CacheOptions
+        {
+            FailOpenOnBackendError = failOpen,
+            Default = new CacheTypeOptions { DefaultFreshSpan = TimeSpan.FromSeconds(10) }
+        };
+        options.RegisterType<string, IMemory>(s => s.DefaultFreshSpan = TimeSpan.FromSeconds(10));
+
+        var persist = new ThrowingPersist();
+        var persistLoader = new Mock<IPersistLoader>(MockBehavior.Strict);
+        persistLoader.Setup(x => x.GetPersist(It.IsAny<Type>())).Returns(persist);
+        var cacheMonitor = new CacheMonitor(persistLoader.Object, options);
+        var fetchQueue = new FetchQueue(cacheMonitor, options, null);
+        var cache = new TimeToLiveCache(cacheMonitor, persistLoader.Object, fetchQueue, options, null);
+        return (cache, persist);
+    }
+
+    /// <summary>An IPersist whose reads and writes always throw, simulating a backend that times out commands.</summary>
+    private sealed class ThrowingPersist : IPersist
+    {
+        private int _getCalls;
+        private int _setCalls;
+
+        public int GetCalls => _getCalls;
+        public int SetCalls => _setCalls;
+
+        public async Task<CacheItem<T>> GetAsync<T>(Key key)
+        {
+            Interlocked.Increment(ref _getCalls);
+            await Task.Yield();
+            throw new TimeoutException("Simulated backend read timeout.");
+        }
+
+        public IAsyncEnumerable<(Key Key, CacheItem<T> CacheItem)> FindAsync<T>(Key key) => throw new NotImplementedException();
+
+        public async Task SetAsync<T>(Key key, CacheItem<T> cacheItem, bool staleWhileRevalidate)
+        {
+            Interlocked.Increment(ref _setCalls);
+            await Task.Yield();
+            throw new TimeoutException("Simulated backend write timeout.");
+        }
+
+        public async Task<bool> BuyMoreTime<T>(Key key)
+        {
+            await Task.Yield();
+            throw new TimeoutException("Simulated backend timeout.");
+        }
+
+        public async Task<bool> Invalidate<T>(Key key)
+        {
+            await Task.Yield();
+            throw new TimeoutException("Simulated backend timeout.");
+        }
+
+        public async Task<bool> DropAsync<T>(Key key)
+        {
+            await Task.Yield();
+            throw new TimeoutException("Simulated backend timeout.");
+        }
+
+        public Task<(bool Success, string Message)> CanConnectAsync() => Task.FromResult((false, "Simulated backend outage."));
+    }
+}

--- a/Tharga.Cache/CacheOptions.cs
+++ b/Tharga.Cache/CacheOptions.cs
@@ -16,6 +16,13 @@ public record CacheOptions
     /// </summary>
     public TimeSpan WatchDogInterval { get; set; } = TimeSpan.FromSeconds(60);
 
+    /// <summary>
+    /// When true (default), an exception thrown by the persist backend is logged and treated as a cache miss
+    /// for reads (control flows to the source loader) and is swallowed for writes — so a backend outage never
+    /// faults the caller. Set to false to restore the previous behavior where backend exceptions propagate.
+    /// </summary>
+    public bool FailOpenOnBackendError { get; set; } = true;
+
     public void RegisterType<TCache, TPersist>(Action<CacheTypeOptions> options = null) where TPersist : IPersist
     {
         var typeOptions = (Default ?? BuildDefault()) with { };

--- a/Tharga.Cache/CacheRegistrationExtensions.cs
+++ b/Tharga.Cache/CacheRegistrationExtensions.cs
@@ -65,7 +65,7 @@ public static class CacheRegistrationExtensions
             var cacheMonitor = s.GetService<IManagedCacheMonitor>();
             var persistLoader = s.GetService<IPersistLoader>();
             var fetchQueue = s.GetService<IFetchQueue>();
-            return new EternalCache(cacheMonitor, persistLoader, fetchQueue, opts);
+            return new EternalCache(cacheMonitor, persistLoader, fetchQueue, opts, CreateCacheLogger(s));
         });
         serviceCollection.TryAddSingleton<ITimeToLiveCache>(s =>
         {
@@ -73,7 +73,7 @@ public static class CacheRegistrationExtensions
             var cacheMonitor = s.GetService<IManagedCacheMonitor>();
             var persistLoader = s.GetService<IPersistLoader>();
             var fetchQueue = s.GetService<IFetchQueue>();
-            return new TimeToLiveCache(cacheMonitor, persistLoader, fetchQueue, opts);
+            return new TimeToLiveCache(cacheMonitor, persistLoader, fetchQueue, opts, CreateCacheLogger(s));
         });
         serviceCollection.TryAddSingleton<ITimeToIdleCache>(s =>
         {
@@ -81,7 +81,7 @@ public static class CacheRegistrationExtensions
             var cacheMonitor = s.GetService<IManagedCacheMonitor>();
             var persistLoader = s.GetService<IPersistLoader>();
             var fetchQueue = s.GetService<IFetchQueue>();
-            return new TimeToIdleCache(cacheMonitor, persistLoader, fetchQueue, opts);
+            return new TimeToIdleCache(cacheMonitor, persistLoader, fetchQueue, opts, CreateCacheLogger(s));
         });
         serviceCollection.TryAddScoped<IScopeCache>(s =>
         {
@@ -89,7 +89,7 @@ public static class CacheRegistrationExtensions
             var cacheMonitor = s.GetService<IManagedCacheMonitor>();
             var persistLoader = s.GetService<IPersistLoader>();
             var fetchQueue = s.GetService<IFetchQueue>();
-            return new EternalCache(cacheMonitor, persistLoader, fetchQueue, opts);
+            return new EternalCache(cacheMonitor, persistLoader, fetchQueue, opts, CreateCacheLogger(s));
         });
 
         serviceCollection.TryAddSingleton<IWatchDogService, WatchDogService>();
@@ -118,6 +118,11 @@ public static class CacheRegistrationExtensions
         {
             o.TryAddType(previouslyRegisteredType.Key, previouslyRegisteredType.Value);
         }
+    }
+
+    private static ILogger CreateCacheLogger(IServiceProvider serviceProvider)
+    {
+        return serviceProvider.GetService<ILoggerFactory>()?.CreateLogger("Tharga.Cache.Cache");
     }
 
     private static void RegisterPersist(IServiceCollection serviceCollection)

--- a/Tharga.Cache/Core/CacheBase.cs
+++ b/Tharga.Cache/Core/CacheBase.cs
@@ -1,4 +1,5 @@
-﻿using Tharga.Cache.Persist;
+﻿using Microsoft.Extensions.Logging;
+using Tharga.Cache.Persist;
 
 namespace Tharga.Cache.Core;
 
@@ -7,9 +8,10 @@ internal abstract class CacheBase : ICache
     private readonly IManagedCacheMonitor _cacheMonitor;
     private readonly IPersistLoader _persistLoader;
     private readonly IFetchQueue _fetchQueue;
+    private readonly ILogger _logger;
     protected readonly CacheOptions _options;
 
-    protected CacheBase(IManagedCacheMonitor cacheMonitor, IPersistLoader persistLoader, IFetchQueue fetchQueue, CacheOptions options)
+    protected CacheBase(IManagedCacheMonitor cacheMonitor, IPersistLoader persistLoader, IFetchQueue fetchQueue, CacheOptions options, ILogger logger = null)
     {
         if (options.MaxConcurrentFetchCount <= 0) throw new InvalidOperationException($"Min value for {nameof(options.MaxConcurrentFetchCount)} is 1.");
 
@@ -17,6 +19,7 @@ internal abstract class CacheBase : ICache
         _persistLoader = persistLoader;
         _fetchQueue = fetchQueue;
         _options = options;
+        _logger = logger;
     }
 
     public event EventHandler<DataSetEventArgs> DataSetEvent;
@@ -36,7 +39,7 @@ internal abstract class CacheBase : ICache
 
         key = key.SetTypeKey<T>();
 
-        var result = await GetPersist<T>().GetAsync<T>(key);
+        var result = await TryGetPersistAsync<T>(key);
 
         if (result.IsValid())
         {
@@ -79,8 +82,10 @@ internal abstract class CacheBase : ICache
 
     private async Task FetchCallback<T>(Key key, CacheItem<T> item, bool staleWhileRevalidate)
     {
-        await GetPersist<T>().SetAsync(key, item, staleWhileRevalidate);
-        await OnSetAsync(key, item, staleWhileRevalidate);
+        if (await TrySetPersistAsync(key, item, staleWhileRevalidate))
+        {
+            await OnSetAsync(key, item, staleWhileRevalidate);
+        }
     }
 
     protected CacheTypeOptions GetTypeOptions<T>()
@@ -93,7 +98,7 @@ internal abstract class CacheBase : ICache
     {
         key = key.SetTypeKey<T>();
 
-        var result = await GetPersist<T>().GetAsync<T>(key);
+        var result = await TryGetPersistAsync<T>(key);
         if (result.IsValid())
         {
             var response = result.GetData();
@@ -124,8 +129,10 @@ internal abstract class CacheBase : ICache
 
         var staleWhileRevalidate = GetTypeOptions<T>().StaleWhileRevalidate;
         var item = CacheItemBuilder.BuildCacheItem(key.KeyParts, data, freshSpan);
-        await GetPersist<T>().SetAsync(key, item, staleWhileRevalidate);
-        await OnSetAsync(key, item, staleWhileRevalidate);
+        if (await TrySetPersistAsync(key, item, staleWhileRevalidate))
+        {
+            await OnSetAsync(key, item, staleWhileRevalidate);
+        }
     }
 
     public virtual async Task<int> DropAsync<T>(Key key)
@@ -204,7 +211,14 @@ internal abstract class CacheBase : ICache
         var moreTimeBought = false;
         if (buyMoreTime)
         {
-            moreTimeBought = await GetPersist<T>().BuyMoreTime<T>(key);
+            try
+            {
+                moreTimeBought = await GetPersist<T>().BuyMoreTime<T>(key);
+            }
+            catch (Exception ex) when (_options.FailOpenOnBackendError)
+            {
+                LogFailOpen(ex, "buy-more-time", key, typeof(T));
+            }
         }
 
         _cacheMonitor.Accessed(typeof(T), key, moreTimeBought);
@@ -226,6 +240,46 @@ internal abstract class CacheBase : ICache
     {
         var persist = _persistLoader.GetPersist(_options.Get<T>().PersistType);
         return persist;
+    }
+
+    /// <summary>
+    /// Reads from the persist backend. When <see cref="CacheOptions.FailOpenOnBackendError"/> is enabled, a
+    /// backend exception is logged and treated as a miss (returns null) so the caller falls back to the source loader.
+    /// </summary>
+    private async Task<CacheItem<T>> TryGetPersistAsync<T>(Key key)
+    {
+        try
+        {
+            return await GetPersist<T>().GetAsync<T>(key);
+        }
+        catch (Exception ex) when (_options.FailOpenOnBackendError)
+        {
+            LogFailOpen(ex, "read", key, typeof(T));
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Writes to the persist backend. When <see cref="CacheOptions.FailOpenOnBackendError"/> is enabled, a backend
+    /// exception is logged and swallowed (returns false) so a failed cache write never faults the caller.
+    /// </summary>
+    private async Task<bool> TrySetPersistAsync<T>(Key key, CacheItem<T> item, bool staleWhileRevalidate)
+    {
+        try
+        {
+            await GetPersist<T>().SetAsync(key, item, staleWhileRevalidate);
+            return true;
+        }
+        catch (Exception ex) when (_options.FailOpenOnBackendError)
+        {
+            LogFailOpen(ex, "write", key, typeof(T));
+            return false;
+        }
+    }
+
+    private void LogFailOpen(Exception ex, string operation, Key key, Type type)
+    {
+        _logger?.LogWarning(ex, "Cache persist {Operation} failed for key '{Key}' on type '{Type}'; failing open ({Message}).", operation, key.Value, type.Name, ex.Message);
     }
 
     private async Task EvictItems<T>(T data)

--- a/Tharga.Cache/Core/EternalCache.cs
+++ b/Tharga.Cache/Core/EternalCache.cs
@@ -1,9 +1,11 @@
-﻿namespace Tharga.Cache.Core;
+﻿using Microsoft.Extensions.Logging;
+
+namespace Tharga.Cache.Core;
 
 internal class EternalCache : CacheBase, IEternalCache, IScopeCache
 {
-    public EternalCache(IManagedCacheMonitor cacheMonitor, IPersistLoader persistLoader, IFetchQueue fetchQueue, CacheOptions options)
-        : base(cacheMonitor, persistLoader, fetchQueue, options)
+    public EternalCache(IManagedCacheMonitor cacheMonitor, IPersistLoader persistLoader, IFetchQueue fetchQueue, CacheOptions options, ILogger logger = null)
+        : base(cacheMonitor, persistLoader, fetchQueue, options, logger)
     {
     }
 

--- a/Tharga.Cache/Core/GenericCache.cs
+++ b/Tharga.Cache/Core/GenericCache.cs
@@ -1,9 +1,11 @@
-﻿namespace Tharga.Cache.Core;
+﻿using Microsoft.Extensions.Logging;
+
+namespace Tharga.Cache.Core;
 
 internal class GenericCache : CacheBase
 {
-    public GenericCache(IManagedCacheMonitor cacheMonitor, IPersistLoader persistLoader, IFetchQueue fetchQueue, CacheOptions options)
-        : base(cacheMonitor, persistLoader, fetchQueue, options)
+    public GenericCache(IManagedCacheMonitor cacheMonitor, IPersistLoader persistLoader, IFetchQueue fetchQueue, CacheOptions options, ILogger logger = null)
+        : base(cacheMonitor, persistLoader, fetchQueue, options, logger)
     {
     }
 

--- a/Tharga.Cache/Core/GenericTimeCache.cs
+++ b/Tharga.Cache/Core/GenericTimeCache.cs
@@ -1,9 +1,11 @@
-﻿namespace Tharga.Cache.Core;
+﻿using Microsoft.Extensions.Logging;
+
+namespace Tharga.Cache.Core;
 
 internal class GenericTimeCache : TimeCacheBase
 {
-    public GenericTimeCache(IManagedCacheMonitor cacheMonitor, IPersistLoader persistLoader, IFetchQueue fetchQueue, CacheOptions options)
-        : base(cacheMonitor, persistLoader, fetchQueue, options)
+    public GenericTimeCache(IManagedCacheMonitor cacheMonitor, IPersistLoader persistLoader, IFetchQueue fetchQueue, CacheOptions options, ILogger logger = null)
+        : base(cacheMonitor, persistLoader, fetchQueue, options, logger)
     {
     }
 }

--- a/Tharga.Cache/Core/TimeCacheBase.cs
+++ b/Tharga.Cache/Core/TimeCacheBase.cs
@@ -1,9 +1,11 @@
-﻿namespace Tharga.Cache.Core;
+﻿using Microsoft.Extensions.Logging;
+
+namespace Tharga.Cache.Core;
 
 internal abstract class TimeCacheBase : CacheBase, ITimeCache
 {
-    protected TimeCacheBase(IManagedCacheMonitor cacheMonitor, IPersistLoader persistLoader, IFetchQueue fetchQueue, CacheOptions options)
-        : base(cacheMonitor, persistLoader, fetchQueue, options)
+    protected TimeCacheBase(IManagedCacheMonitor cacheMonitor, IPersistLoader persistLoader, IFetchQueue fetchQueue, CacheOptions options, ILogger logger = null)
+        : base(cacheMonitor, persistLoader, fetchQueue, options, logger)
     {
     }
 

--- a/Tharga.Cache/Core/TimeToIdleCache.cs
+++ b/Tharga.Cache/Core/TimeToIdleCache.cs
@@ -1,9 +1,11 @@
-﻿namespace Tharga.Cache.Core;
+﻿using Microsoft.Extensions.Logging;
+
+namespace Tharga.Cache.Core;
 
 internal class TimeToIdleCache : TimeCacheBase, ITimeToIdleCache
 {
-    public TimeToIdleCache(IManagedCacheMonitor cacheMonitor, IPersistLoader persistLoader, IFetchQueue fetchQueue, CacheOptions options)
-        : base(cacheMonitor, persistLoader, fetchQueue, options)
+    public TimeToIdleCache(IManagedCacheMonitor cacheMonitor, IPersistLoader persistLoader, IFetchQueue fetchQueue, CacheOptions options, ILogger logger = null)
+        : base(cacheMonitor, persistLoader, fetchQueue, options, logger)
     {
     }
 

--- a/Tharga.Cache/Core/TimeToLiveCache.cs
+++ b/Tharga.Cache/Core/TimeToLiveCache.cs
@@ -1,9 +1,11 @@
-﻿namespace Tharga.Cache.Core;
+﻿using Microsoft.Extensions.Logging;
+
+namespace Tharga.Cache.Core;
 
 internal class TimeToLiveCache : TimeCacheBase, ITimeToLiveCache
 {
-    public TimeToLiveCache(IManagedCacheMonitor cacheMonitor, IPersistLoader persistLoader, IFetchQueue fetchQueue, CacheOptions options)
-        : base(cacheMonitor, persistLoader, fetchQueue, options)
+    public TimeToLiveCache(IManagedCacheMonitor cacheMonitor, IPersistLoader persistLoader, IFetchQueue fetchQueue, CacheOptions options, ILogger logger = null)
+        : base(cacheMonitor, persistLoader, fetchQueue, options, logger)
     {
     }
 }

--- a/Tharga.Cache/README.md
+++ b/Tharga.Cache/README.md
@@ -12,6 +12,7 @@ A flexible .NET caching library with multiple cache strategies, configurable evi
 - **Eviction policies** — LRU, FIFO, or Random when size or count limits are reached
 - **Stale-while-revalidate** — return cached data instantly while refreshing in the background
 - **Pluggable persistence** — in-memory by default, with optional Redis, MongoDB, and file backends
+- **Fail-open** — when a persist backend is unreachable, reads fall through to the source loader and writes are skipped, so a cache outage never faults the caller (`CacheOptions.FailOpenOnBackendError`, on by default)
 - **Composite keys** — build cache keys from multiple parts with `KeyBuilder`
 - **Monitoring** — inspect cache state, item counts, and fetch queue depth via `ICacheMonitor`
 - **Background cleanup** — built-in WatchDog service removes stale entries automatically


### PR DESCRIPTION
Closes #50.

## Problem
When the persist backend (Redis) times out *commands* rather than cleanly failing to connect, `ICache.GetAsync<T>(key, fetch)` threw instead of falling back to the `fetch` loader. A production Redis outage therefore took the whole service down (every read retried ~15s then threw, blocked threads exhausted the pool at ~60k queued items) even though the backing store was healthy.

## Changes

**1. Fail-open in `CacheBase` (provider-agnostic).** A backend exception is caught and:
- reads → logged, treated as a miss → control flows to the `fetch` source loader (`GetCoreAsync`, `PeekAsync`, `BuyMoreTime`);
- writes → logged and swallowed, never fault the caller (`FetchCallback`, `SetCoreAsync`).

Gated by an exception filter `when (_options.FailOpenOnBackendError)`, so setting the new `CacheOptions.FailOpenOnBackendError = false` restores the previous throwing behavior exactly. Because it lives in the base class it protects **all** `IPersist` backends (Redis/MongoDB/File). `CacheBase` gained a nullable `ILogger`, threaded through the 5 cache subclasses and the DI factory lambdas.

**2. Circuit breaker in the Redis provider.** New internal `RedisResiliencePolicy` factory builds a Polly circuit breaker (outer) wrapping the existing retry (inner), so once the circuit is open calls fail fast (`BrokenCircuitException`, caught by the core fail-open) instead of paying retry latency per call — the fix for the thread-pool starvation. Half-open auto-recovers. `CanConnectAsync` returns `(false, "circuit open")` instead of throwing.

**3. Options.** `CacheOptions.FailOpenOnBackendError` (default `true`); `RedisCacheOptions.RetryCount` / `CircuitBreakerFailureThreshold` / `CircuitBreakerDuration` / `CommandTimeout`.

## Acceptance criteria
- [x] With the backend down/timing out, `GetAsync(key, fetch)` returns `fetch()`'s result and does not throw.
- [x] A cache *write* failure does not fault the caller.
- [x] Under a sustained outage, calls fail fast once the breaker is open and recover automatically.

## Tests
- `FailOpenTests` (4) — throwing `IPersist`: Get returns the loader result; read/write failures don't fault; `FailOpenOnBackendError=false` re-throws.
- `RedisResiliencePolicyTests` (3) — breaker opens after the threshold and fast-fails without invoking the backend; success passes through; transient failures still retry.
- Full solution builds clean. Core: 478 pass (4 new). Redis: 5 pass.

Docs: README updated (core feature bullet + Redis "Resilience (fail-open)" section).