### PR TITLE
chore: update NuGet packages

### DIFF
--- a/Sample/Tharga.Cache.WebApi/Tharga.Cache.WebApi.csproj
+++ b/Sample/Tharga.Cache.WebApi/Tharga.Cache.WebApi.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tharga.Cache.File.Tests/Tharga.Cache.File.Tests.csproj
+++ b/Tharga.Cache.File.Tests/Tharga.Cache.File.Tests.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="8.10.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/Tharga.Cache.MongoDB.Tests/Tharga.Cache.MongoDB.Tests.csproj
+++ b/Tharga.Cache.MongoDB.Tests/Tharga.Cache.MongoDB.Tests.csproj
@@ -8,7 +8,7 @@
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="8.10.0" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>

--- a/Tharga.Cache.MongoDB/Tharga.Cache.MongoDB.csproj
+++ b/Tharga.Cache.MongoDB/Tharga.Cache.MongoDB.csproj
@@ -39,7 +39,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Tharga.MongoDB" Version="2.11.0" />
+    <PackageReference Include="Tharga.MongoDB" Version="2.11.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Tharga.Cache\Tharga.Cache.csproj" />

--- a/Tharga.Cache.Redis.Tests/Tharga.Cache.Redis.Tests.csproj
+++ b/Tharga.Cache.Redis.Tests/Tharga.Cache.Redis.Tests.csproj
@@ -10,7 +10,7 @@
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="8.10.0" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>

--- a/Tharga.Cache.Redis/Tharga.Cache.Redis.csproj
+++ b/Tharga.Cache.Redis/Tharga.Cache.Redis.csproj
@@ -41,7 +41,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Polly" Version="8.7.0" />
-		<PackageReference Include="StackExchange.Redis" Version="2.13.17" />
+		<PackageReference Include="StackExchange.Redis" Version="3.0.7" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Tharga.Cache.Tests/Tharga.Cache.Tests.csproj
+++ b/Tharga.Cache.Tests/Tharga.Cache.Tests.csproj
@@ -10,7 +10,7 @@
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="8.10.0" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Summary
Updates all outdated NuGet packages across the solution.

| Package | From | To |
|---|---|---|
| Microsoft.NET.Test.Sdk | 18.6.0 | 18.7.0 |
| Tharga.MongoDB | 2.11.0 | 2.11.2 |
| Swashbuckle.AspNetCore | 10.2.1 | 10.2.3 |
| StackExchange.Redis | 2.13.17 | **3.0.7** (major) |

## Verification
- Solution builds in Release with no new warnings/errors.
- StackExchange.Redis 3.0 major upgrade compiled with no source changes required; all Redis tests pass.
- 477/478 core tests pass; the single failure is a pre-existing flaky timing-sensitive throttle test (a different parametrization fails each run), unrelated to these package changes.