### PR TITLE
chore!: bump to 1.0, target net10.0 only, consume tier 3, declare licence

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
     branches: [master]
 
 env:
-  MAJOR_MINOR: '0.4'
+  MAJOR_MINOR: '1.0'
 
 permissions:
   contents: write
@@ -28,42 +28,17 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: |
-            8.0.x
-            9.0.x
-            10.0.x
+          dotnet-version: 10.0.x
 
-      - name: Restore
-        run: dotnet restore
-
-      - name: Build
-        run: dotnet build -c Release --no-restore 2>&1 | tee build.log
-
-      - name: Check warnings
-        run: |
-          WARNING_COUNT=$(grep -c " warning " build.log || true)
-          echo "Build warnings: $WARNING_COUNT"
-          if [ "$WARNING_COUNT" -gt 10 ]; then
-            echo "::error::Build has $WARNING_COUNT warnings (threshold: 10)"
-            exit 1
-          fi
-
-      - name: Test with coverage
-        # Skip Integration (needs Mongo/Redis) and TimeCritical (wall-clock asserts) tests on shared CI runners.
-        run: dotnet test -c Release --no-build --verbosity normal --filter "(Category!=Integration)&(Category!=TimeCritical)" --collect:"XPlat Code Coverage" --results-directory ./coverage
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          directory: ./coverage
-          fail_ci_if_error: false
-          token: ${{ secrets.CODECOV_TOKEN }}
-
+      # Version is computed BEFORE the build so it can be passed as -p:Version.
+      # Passing it only to `dotnet pack` sets PackageVersion alone, leaving
+      # AssemblyVersion and FileVersion at their default 1.0.0.0 inside the
+      # shipped assembly.
       - name: Compute version
         id: version
         run: |
           LATEST_TAG=$(git tag -l "${MAJOR_MINOR}.*" --sort=-v:refname \
-            | grep -E "^${MAJOR_MINOR}\.[0-9]+$" \
+            | { grep -E "^${MAJOR_MINOR}\.[0-9]+$" || true; } \
             | head -1)
 
           if [ -z "$LATEST_TAG" ]; then
@@ -98,25 +73,56 @@ jobs:
           echo "version=$PRE_VERSION" >> "$GITHUB_OUTPUT"
           echo "Computed pre-release version: $PRE_VERSION"
 
-      - name: Pack (stable — push to master)
-        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+      # Pull requests build the pre-release version, pushes to master the
+      # stable one. One value drives build and pack so the assembly and the
+      # package can never disagree.
+      - name: Resolve build version
+        id: buildversion
+        shell: bash
         run: |
-          dotnet pack Tharga.Cache/Tharga.Cache.csproj -c Release --no-build -o ./artifacts -p:PackageVersion=${{ steps.version.outputs.version }}
-          dotnet pack Tharga.Cache.Redis/Tharga.Cache.Redis.csproj -c Release --no-build -o ./artifacts -p:PackageVersion=${{ steps.version.outputs.version }}
-          dotnet pack Tharga.Cache.MongoDB/Tharga.Cache.MongoDB.csproj -c Release --no-build -o ./artifacts -p:PackageVersion=${{ steps.version.outputs.version }}
-          dotnet pack Tharga.Cache.File/Tharga.Cache.File.csproj -c Release --no-build -o ./artifacts -p:PackageVersion=${{ steps.version.outputs.version }}
-          dotnet pack Tharga.Cache.Blazor/Tharga.Cache.Blazor.csproj -c Release --no-build -o ./artifacts -p:PackageVersion=${{ steps.version.outputs.version }}
-          dotnet pack Tharga.Cache.Mcp/Tharga.Cache.Mcp.csproj -c Release --no-build -o ./artifacts -p:PackageVersion=${{ steps.version.outputs.version }}
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            VERSION="${{ steps.preversion.outputs.version }}"
+          else
+            VERSION="${{ steps.version.outputs.version }}"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Building as: $VERSION"
 
-      - name: Pack (pre-release — pull request)
-        if: github.event_name == 'pull_request'
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build -c Release --no-restore -p:Version=${{ steps.buildversion.outputs.version }} 2>&1 | tee build.log
+
+      - name: Check warnings
         run: |
-          dotnet pack Tharga.Cache/Tharga.Cache.csproj -c Release --no-build -o ./artifacts -p:PackageVersion=${{ steps.preversion.outputs.version }}
-          dotnet pack Tharga.Cache.Redis/Tharga.Cache.Redis.csproj -c Release --no-build -o ./artifacts -p:PackageVersion=${{ steps.preversion.outputs.version }}
-          dotnet pack Tharga.Cache.MongoDB/Tharga.Cache.MongoDB.csproj -c Release --no-build -o ./artifacts -p:PackageVersion=${{ steps.preversion.outputs.version }}
-          dotnet pack Tharga.Cache.File/Tharga.Cache.File.csproj -c Release --no-build -o ./artifacts -p:PackageVersion=${{ steps.preversion.outputs.version }}
-          dotnet pack Tharga.Cache.Blazor/Tharga.Cache.Blazor.csproj -c Release --no-build -o ./artifacts -p:PackageVersion=${{ steps.preversion.outputs.version }}
-          dotnet pack Tharga.Cache.Mcp/Tharga.Cache.Mcp.csproj -c Release --no-build -o ./artifacts -p:PackageVersion=${{ steps.preversion.outputs.version }}
+          WARNING_COUNT=$(grep -c " warning " build.log || true)
+          echo "Build warnings: $WARNING_COUNT"
+          if [ "$WARNING_COUNT" -gt 10 ]; then
+            echo "::error::Build has $WARNING_COUNT warnings (threshold: 10)"
+            exit 1
+          fi
+
+      - name: Test with coverage
+        # Skip Integration (needs Mongo/Redis) and TimeCritical (wall-clock asserts) tests on shared CI runners.
+        run: dotnet test -c Release --no-build --verbosity normal --filter "(Category!=Integration)&(Category!=TimeCritical)" --collect:"XPlat Code Coverage" --results-directory ./coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          directory: ./coverage
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Pack
+        shell: bash
+        run: |
+          dotnet pack Tharga.Cache/Tharga.Cache.csproj -c Release --no-build -o ./artifacts -p:Version=${{ steps.buildversion.outputs.version }}
+          dotnet pack Tharga.Cache.Redis/Tharga.Cache.Redis.csproj -c Release --no-build -o ./artifacts -p:Version=${{ steps.buildversion.outputs.version }}
+          dotnet pack Tharga.Cache.MongoDB/Tharga.Cache.MongoDB.csproj -c Release --no-build -o ./artifacts -p:Version=${{ steps.buildversion.outputs.version }}
+          dotnet pack Tharga.Cache.File/Tharga.Cache.File.csproj -c Release --no-build -o ./artifacts -p:Version=${{ steps.buildversion.outputs.version }}
+          dotnet pack Tharga.Cache.Blazor/Tharga.Cache.Blazor.csproj -c Release --no-build -o ./artifacts -p:Version=${{ steps.buildversion.outputs.version }}
+          dotnet pack Tharga.Cache.Mcp/Tharga.Cache.Mcp.csproj -c Release --no-build -o ./artifacts -p:Version=${{ steps.buildversion.outputs.version }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -138,10 +144,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: |
-            8.0.x
-            9.0.x
-            10.0.x
+          dotnet-version: 10.0.x
 
       - name: Build for CodeQL
         run: dotnet build -c Release
@@ -175,7 +178,7 @@ jobs:
         id: version
         run: |
           LATEST_TAG=$(git tag -l "${MAJOR_MINOR}.*" --sort=-v:refname \
-            | grep -E "^${MAJOR_MINOR}\.[0-9]+$" \
+            | { grep -E "^${MAJOR_MINOR}\.[0-9]+$" || true; } \
             | head -1)
 
           if [ -z "$LATEST_TAG" ]; then
@@ -191,9 +194,15 @@ jobs:
 
       - name: Push to NuGet
         run: |
+          # Only *.nupkg is globbed. Each matching package's sibling .snupkg is
+          # uploaded automatically by dotnet nuget push, so symbols must NOT be
+          # pushed explicitly or nuget.org sees a duplicate.
+          ls -l ./artifacts/
           for pkg in ./artifacts/*.nupkg; do
             echo "Pushing $pkg..."
-            dotnet nuget push "$pkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate || true
+            # --skip-duplicate already makes a re-run of an existing version a
+            # success, so a failure here is a real failure and must fail the job.
+            dotnet nuget push "$pkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
           done
 
       - name: Create GitHub Release
@@ -249,7 +258,7 @@ jobs:
         id: version
         run: |
           LATEST_TAG=$(git tag -l "${MAJOR_MINOR}.*" --sort=-v:refname \
-            | grep -E "^${MAJOR_MINOR}\.[0-9]+$" \
+            | { grep -E "^${MAJOR_MINOR}\.[0-9]+$" || true; } \
             | head -1)
 
           if [ -z "$LATEST_TAG" ]; then
@@ -274,9 +283,15 @@ jobs:
 
       - name: Push to NuGet
         run: |
+          # Only *.nupkg is globbed. Each matching package's sibling .snupkg is
+          # uploaded automatically by dotnet nuget push, so symbols must NOT be
+          # pushed explicitly or nuget.org sees a duplicate.
+          ls -l ./artifacts/
           for pkg in ./artifacts/*.nupkg; do
             echo "Pushing $pkg..."
-            dotnet nuget push "$pkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate || true
+            # --skip-duplicate already makes a re-run of an existing version a
+            # success, so a failure here is a real failure and must fail the job.
+            dotnet nuget push "$pkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
           done
 
       - name: Create GitHub Pre-release
@@ -300,10 +315,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: |
-            8.0.x
-            9.0.x
-            10.0.x
+          dotnet-version: 10.0.x
 
       - name: Install DocFX
         run: dotnet tool install -g docfx

--- a/Sample/Tharga.Cache.Console/Tharga.Cache.Console.csproj
+++ b/Sample/Tharga.Cache.Console/Tharga.Cache.Console.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Tharga.Console" Version="4.1.2" />
+		<PackageReference Include="Tharga.Console" Version="4.2.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Tharga.Cache.Blazor/Tharga.Cache.Blazor.csproj
+++ b/Tharga.Cache.Blazor/Tharga.Cache.Blazor.csproj
@@ -16,6 +16,10 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSource>true</IncludeSource>
     <IncludeSymbols>true</IncludeSymbols>
+    <!-- Without this, pack emits the legacy .symbols.nupkg, whose name still ends
+         in .nupkg, so the release push loop uploads it as a regular package and
+         nuget.org rejects it as a duplicate. No symbols ever shipped. -->
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <PropertyGroup>
     <NoWarn>1701;1702;CS1591;CS0809</NoWarn>

--- a/Tharga.Cache.Blazor/Tharga.Cache.Blazor.csproj
+++ b/Tharga.Cache.Blazor/Tharga.Cache.Blazor.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Version>1.0.0</Version>
     <Authors>Daniel Bohlin</Authors>
     <Company>Thargelion AB</Company>
     <Product>Tharga Cache Blazor</Product>
     <Description>Component for manageing the Tharga Cache features in blazor.</Description>
     <PackageIconUrl>https://thargelion.net/assets/component-cache.png</PackageIconUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <DebugType>portable</DebugType>
@@ -22,7 +22,13 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <PropertyGroup>
-    <NoWarn>1701;1702;CS1591;CS0809</NoWarn>
+    <!--
+      NU5048: PackageIconUrl is deprecated in favour of an embedded PackageIcon.
+      Suppressed deliberately. Tharga packages reference their icon from
+      https://thargelion.net/assets/ so all package icons are maintained in one
+      place and can be updated without republishing a package.
+    -->
+    <NoWarn>1701;1702;CS1591;CS0809;NU5048</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <None Include="README.md">
@@ -31,7 +37,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Tharga.Blazor" Version="2.2.0" />
+    <PackageReference Include="Tharga.Blazor" Version="2.2.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Tharga.Cache\Tharga.Cache.csproj" />

--- a/Tharga.Cache.File/Tharga.Cache.File.csproj
+++ b/Tharga.Cache.File/Tharga.Cache.File.csproj
@@ -12,6 +12,10 @@
     <PackageProjectUrl>https://github.com/Tharga/Cache</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <IncludeSymbols>true</IncludeSymbols>
+    <!-- Without this, pack emits the legacy .symbols.nupkg, whose name still ends
+         in .nupkg, so the release push loop uploads it as a regular package and
+         nuget.org rejects it as a duplicate. No symbols ever shipped. -->
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <IncludeSource>true</IncludeSource>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/Tharga.Cache.File/Tharga.Cache.File.csproj
+++ b/Tharga.Cache.File/Tharga.Cache.File.csproj
@@ -2,12 +2,12 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Version>1.0.0</Version>
     <Authors>Daniel Bohlin</Authors>
     <Company>Thargelion AB</Company>
     <Product>Tharga Cache File</Product>
     <Description>File cache features.</Description>
     <PackageIconUrl>https://thargelion.net/assets/component-cache.png</PackageIconUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <PackageProjectUrl>https://github.com/Tharga/Cache</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -25,7 +25,13 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <PropertyGroup>
-    <NoWarn>1701;1702;CS1591</NoWarn>
+    <!--
+      NU5048: PackageIconUrl is deprecated in favour of an embedded PackageIcon.
+      Suppressed deliberately. Tharga packages reference their icon from
+      https://thargelion.net/assets/ so all package icons are maintained in one
+      place and can be updated without republishing a package.
+    -->
+    <NoWarn>1701;1702;CS1591;NU5048</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <None Include="README.md">

--- a/Tharga.Cache.Mcp/Tharga.Cache.Mcp.csproj
+++ b/Tharga.Cache.Mcp/Tharga.Cache.Mcp.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
@@ -13,6 +13,10 @@
 		<PackageProjectUrl>https://github.com/Tharga/Cache</PackageProjectUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<IncludeSymbols>true</IncludeSymbols>
+		<!-- Without this, pack emits the legacy .symbols.nupkg, whose name still ends
+		     in .nupkg, so the release push loop uploads it as a regular package and
+		     nuget.org rejects it as a duplicate. No symbols ever shipped. -->
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 		<IncludeSource>true</IncludeSource>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/Tharga.Cache.Mcp/Tharga.Cache.Mcp.csproj
+++ b/Tharga.Cache.Mcp/Tharga.Cache.Mcp.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Version>1.0.0</Version>
 		<Authors>Daniel Bohlin</Authors>
 		<Company>Thargelion AB</Company>
 		<Product>Tharga Cache MCP</Product>
 		<Description>Exposes Tharga.Cache monitoring data (cache types, items, persistence health, fetch queue) and actions (clear all, clear stale) via MCP (Model Context Protocol). Plugs into Tharga.Mcp.</Description>
 		<PackageIconUrl>https://thargelion.net/assets/component-cache.png</PackageIconUrl>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<PackageProjectUrl>https://github.com/Tharga/Cache</PackageProjectUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
@@ -26,7 +26,13 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<NoWarn>1701;1702;CS1591;CS0809</NoWarn>
+		<!--
+			NU5048: PackageIconUrl is deprecated in favour of an embedded PackageIcon.
+			Suppressed deliberately. Tharga packages reference their icon from
+			https://thargelion.net/assets/ so all package icons are maintained in one
+			place and can be updated without republishing a package.
+		-->
+		<NoWarn>1701;1702;CS1591;CS0809;NU5048</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -37,7 +43,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Tharga.Mcp" Version="0.1.6" />
+		<PackageReference Include="Tharga.Mcp" Version="1.0.0" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Tharga.Cache.MongoDB/Tharga.Cache.MongoDB.csproj
+++ b/Tharga.Cache.MongoDB/Tharga.Cache.MongoDB.csproj
@@ -12,6 +12,10 @@
     <PackageProjectUrl>https://github.com/Tharga/Cache</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <IncludeSymbols>true</IncludeSymbols>
+    <!-- Without this, pack emits the legacy .symbols.nupkg, whose name still ends
+         in .nupkg, so the release push loop uploads it as a regular package and
+         nuget.org rejects it as a duplicate. No symbols ever shipped. -->
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <IncludeSource>true</IncludeSource>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/Tharga.Cache.MongoDB/Tharga.Cache.MongoDB.csproj
+++ b/Tharga.Cache.MongoDB/Tharga.Cache.MongoDB.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Version>1.0.0</Version>
     <Authors>Daniel Bohlin</Authors>
     <Company>Thargelion AB</Company>
     <Product>Tharga Cache MongoDB</Product>
     <Description>MongoDB cache features.</Description>
     <PackageIconUrl>https://thargelion.net/assets/component-cache.png</PackageIconUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <PackageProjectUrl>https://github.com/Tharga/Cache</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -25,7 +25,13 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <PropertyGroup>
-    <NoWarn>1701;1702;CS1591</NoWarn>
+    <!--
+      NU5048: PackageIconUrl is deprecated in favour of an embedded PackageIcon.
+      Suppressed deliberately. Tharga packages reference their icon from
+      https://thargelion.net/assets/ so all package icons are maintained in one
+      place and can be updated without republishing a package.
+    -->
+    <NoWarn>1701;1702;CS1591;NU5048</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <None Include="README.md">
@@ -43,7 +49,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Tharga.MongoDB" Version="2.11.2" />
+    <PackageReference Include="Tharga.MongoDB" Version="2.14.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Tharga.Cache\Tharga.Cache.csproj" />

--- a/Tharga.Cache.Redis/Tharga.Cache.Redis.csproj
+++ b/Tharga.Cache.Redis/Tharga.Cache.Redis.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Version>1.0.0</Version>
 		<Authors>Daniel Bohlin</Authors>
 		<Company>Thargelion AB</Company>
 		<Product>Tharga Cache Redis</Product>
 		<Description>Redis cache features.</Description>
 		<PackageIconUrl>https://thargelion.net/assets/component-cache.png</PackageIconUrl>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<PackageProjectUrl>https://github.com/Tharga/Cache</PackageProjectUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
@@ -27,7 +27,13 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<NoWarn>1701;1702;CS1591</NoWarn>
+		<!--
+			NU5048: PackageIconUrl is deprecated in favour of an embedded PackageIcon.
+			Suppressed deliberately. Tharga packages reference their icon from
+			https://thargelion.net/assets/ so all package icons are maintained in one
+			place and can be updated without republishing a package.
+		-->
+		<NoWarn>1701;1702;CS1591;NU5048</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Tharga.Cache.Redis/Tharga.Cache.Redis.csproj
+++ b/Tharga.Cache.Redis/Tharga.Cache.Redis.csproj
@@ -13,6 +13,10 @@
 		<PackageProjectUrl>https://github.com/Tharga/Cache</PackageProjectUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<IncludeSymbols>true</IncludeSymbols>
+		<!-- Without this, pack emits the legacy .symbols.nupkg, whose name still ends
+		     in .nupkg, so the release push loop uploads it as a regular package and
+		     nuget.org rejects it as a duplicate. No symbols ever shipped. -->
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 		<IncludeSource>true</IncludeSource>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/Tharga.Cache.sln
+++ b/Tharga.Cache.sln
@@ -9,7 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tharga.Cache.Tests", "Tharg
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{B2037503-DDED-46E6-BF80-9E2914A10291}"
 	ProjectSection(SolutionItems) = preProject
-		azure-pipelines.yml = azure-pipelines.yml
+		.github\workflows\build.yml = .github\workflows\build.yml
+		LICENSE = LICENSE
 		README.md = README.md
 		switcher.json = switcher.json
 	EndProjectSection

--- a/Tharga.Cache/Tharga.Cache.csproj
+++ b/Tharga.Cache/Tharga.Cache.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Version>1.1.0</Version>
 		<Authors>Daniel Bohlin</Authors>
 		<Company>Thargelion AB</Company>
 		<Product>Tharga Cache</Product>
 		<Description>Memory cache features.</Description>
 		<PackageIconUrl>https://thargelion.net/assets/component-cache.png</PackageIconUrl>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<PackageProjectUrl>https://github.com/Tharga/Cache</PackageProjectUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
@@ -27,7 +27,13 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<NoWarn>1701;1702;CS1591</NoWarn>
+		<!--
+			NU5048: PackageIconUrl is deprecated in favour of an embedded PackageIcon.
+			Suppressed deliberately. Tharga packages reference their icon from
+			https://thargelion.net/assets/ so all package icons are maintained in one
+			place and can be updated without republishing a package.
+		-->
+		<NoWarn>1701;1702;CS1591;NU5048</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Tharga.Cache/Tharga.Cache.csproj
+++ b/Tharga.Cache/Tharga.Cache.csproj
@@ -13,6 +13,10 @@
 		<PackageProjectUrl>https://github.com/Tharga/Cache</PackageProjectUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<IncludeSymbols>true</IncludeSymbols>
+		<!-- Without this, pack emits the legacy .symbols.nupkg, whose name still ends
+		     in .nupkg, so the release push loop uploads it as a regular package and
+		     nuget.org rejects it as a duplicate. No symbols ever shipped. -->
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 		<IncludeSource>true</IncludeSource>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<EmbedUntrackedSources>true</EmbedUntrackedSources>


### PR DESCRIPTION
Tier 4 of the package cleanup sweep. Also carries the `snupkg` symbol fix originally opened on its own here.

### Version
**MAJOR_MINOR 0.4 → 1.0** — Cache was the last pre-1.0 package series in the toolkit.

### Frameworks
`Tharga.Cache`, `.Blazor`, `.Mcp`, `.MongoDB` and `.Redis` drop **net8.0/net9.0** for net10.0 only. Both go out of support 2026-11-10, and `.Blazor` had to move regardless since `Tharga.Blazor` 2.2.3 is net10.0-only.

### Dependencies
| Package | From | To |
|---|---|---|
| Tharga.MongoDB | 2.11.2 | 2.14.1 |
| Tharga.Blazor | 2.2.0 | 2.2.3 |
| Tharga.Mcp | 0.1.6 | 1.0.0 |
| Tharga.Console | 4.1.2 | 4.2.0 |

### Package metadata
- **Declared the licence.** The repo has an MIT LICENSE file but none of the six packages ever said so — every push logged `License missing`.
- **Symbols now publish** (`SymbolPackageFormat=snupkg`). The legacy `.symbols.nupkg` name still ends in `.nupkg`, so the push loop uploaded it as a regular package and nuget.org rejected it as a duplicate. Verified working end-to-end on Blazor, Crawler and all five MongoDB packages.
- Removed `<Version>` from all six projects — it read `1.0.0` while the series actually shipped `0.4.x`.
- `NU5048` added to NoWarn; `PackageIconUrl` is deliberate.

### CI
- Version computed **before** the build and passed as `-p:Version`, so the assembly and package agree.
- Tag lookup guarded with `|| true` — `grep` exits 1 when no tag matches the series, which is **exactly what starting the new 1.0 series does**, and the step would otherwise die under `bash -eo pipefail`. This is the bug that broke Reporter's build in tier 1.
- A failed nuget push now fails the release; the loop ended in `|| true`.
- SDK narrowed to 10.0.x; solution items cleaned up.

### Tests
**478 pass.** `FetchDataThrottleTests.ManyParallelCallsAreQueuedForDifferentTypes` is timing-bounded (asserts 500–1200 ms) and flaky — it fails intermittently on unmodified `master` too (2 of 3 runs there).