### PR TITLE
fix: pass the cache key to Mongo as an id, not as a JSON filter (#57)

### DIFF
--- a/Tharga.Cache.MongoDB.Tests/MongoDBKeyFilterTests.cs
+++ b/Tharga.Cache.MongoDB.Tests/MongoDBKeyFilterTests.cs
@@ -1,0 +1,68 @@
+﻿using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+using MongoDB.Driver;
+using Moq;
+using Tharga.Cache.Core;
+using Tharga.MongoDB;
+using Xunit;
+using Sut = Tharga.Cache.MongoDB.MongoDB;
+
+namespace Tharga.Cache.MongoDB.Tests;
+
+/// <summary>
+/// The cache key has to reach Mongo as an id, never as a filter document.
+/// </summary>
+/// <remarks>
+/// DeleteOneAsync and UpdateOneAsync have no TKey overload, so a bare string is picked up by the
+/// FilterDefinition overload through the driver's implicit string -> JsonFilterDefinition conversion.
+/// That compiles cleanly and then fails at runtime, once per drop, with
+/// "JSON reader was expecting a value but found '&lt;TypeName&gt;'" - because CacheBase prefixes every
+/// key with the type name. Rendering the filter here is what tells the two apart.
+/// </remarks>
+public class MongoDBKeyFilterTests
+{
+    private const string CacheKey = "FeedStatusDto.my-feed-key";
+
+    private static BsonDocument Render(FilterDefinition<CacheEntity> filter)
+    {
+        return filter.Render(new RenderArgs<CacheEntity>(BsonSerializer.SerializerRegistry.GetSerializer<CacheEntity>(), BsonSerializer.SerializerRegistry));
+    }
+
+    private static (Sut Sut, Mock<ICacheRepositoryCollection> Collection) BuildSut()
+    {
+        var collection = new Mock<ICacheRepositoryCollection>();
+
+        var collectionProvider = new Mock<ICollectionProvider>();
+        collectionProvider
+            .Setup(x => x.GetCollection<ICacheRepositoryCollection, CacheEntity, string>(It.IsAny<DatabaseContext>()))
+            .Returns(collection.Object);
+
+        var sut = new Sut(collectionProvider.Object, Mock.Of<IManagedCacheMonitor>(), Options.Create(new MongoDBCacheOptions()), Mock.Of<ILogger<Sut>>());
+        return (sut, collection);
+    }
+
+    [Fact]
+    public async Task DropAsync_FiltersOnTheIdRatherThanParsingTheKeyAsJson()
+    {
+        var (sut, collection) = BuildSut();
+        FilterDefinition<CacheEntity> captured = null;
+        collection
+            .Setup(x => x.DeleteOneAsync(It.IsAny<FilterDefinition<CacheEntity>>(), It.IsAny<OneOption<CacheEntity>>(), It.IsAny<IClientSessionHandle>()))
+            .Callback<FilterDefinition<CacheEntity>, OneOption<CacheEntity>, IClientSessionHandle>((f, _, _) => captured = f)
+            .ReturnsAsync((CacheEntity)null);
+
+        await sut.DropAsync<object>(CacheKey);
+
+        captured.Should().NotBeNull();
+        var rendered = Render(captured);
+        rendered.ElementCount.Should().Be(1);
+        rendered.GetElement(0).Name.Should().Be("_id");
+        rendered.GetElement(0).Value.AsString.Should().Be(CacheKey);
+    }
+
+}
+
+

--- a/Tharga.Cache.MongoDB/MongoDB.cs
+++ b/Tharga.Cache.MongoDB/MongoDB.cs
@@ -42,7 +42,7 @@ internal class MongoDB : IMongoDB
         {
             if (!item.StaleWhileRevalidate && item.FreshSpan.HasValue && item.FreshSpan.Value != TimeSpan.MaxValue && item.CreateTime.Add(item.FreshSpan.Value) < DateTime.UtcNow)
             {
-                await collection.DeleteOneAsync(item.Id);
+                await collection.DeleteOneAsync(ById(item.Id));
                 return null;
             }
 
@@ -104,15 +104,30 @@ internal class MongoDB : IMongoDB
     public async Task<bool> DropAsync<T>(Key key)
     {
         var collection = GetCollection();
-        var item = await collection.DeleteOneAsync(key.Value);
+        var item = await collection.DeleteOneAsync(ById(key.Value));
         return item != null;
+    }
+
+    /// <summary>
+    /// The id of a cache entity as an explicit filter.
+    /// </summary>
+    /// <remarks>
+    /// There is no DeleteOneAsync(TKey) overload, so a bare string is picked up by
+    /// DeleteOneAsync(FilterDefinition&lt;CacheEntity&gt;) through the driver's implicit
+    /// string -&gt; JsonFilterDefinition conversion. That compiles, and then Mongo parses the
+    /// cache key as a JSON filter document: "JSON reader was expecting a value but found 'MyType'".
+    /// Building the filter here means the key can only ever be read as an id.
+    /// </remarks>
+    private static FilterDefinition<CacheEntity> ById(string id)
+    {
+        return new FilterDefinitionBuilder<CacheEntity>().Eq(x => x.Id, id);
     }
 
     private async Task<bool> SetUpdateTime(Key key, DateTime updateTime)
     {
         var collection = GetCollection();
         var update = new UpdateDefinitionBuilder<CacheEntity>().Set(x => x.UpdateTime, updateTime);
-        var result = await collection.UpdateOneAsync(key.Value, update, OneOption<CacheEntity>.SingleOrDefault);
+        var result = await collection.UpdateOneAsync(ById(key.Value), update, OneOption<CacheEntity>.SingleOrDefault);
         return result.Before != null;
     }
 
@@ -151,3 +166,4 @@ internal class MongoDB : IMongoDB
         return ValueTask.CompletedTask;
     }
 }
+

--- a/Tharga.Cache/Tharga.Cache.csproj
+++ b/Tharga.Cache/Tharga.Cache.csproj
@@ -48,6 +48,7 @@
 		<InternalsVisibleTo Include="Tharga.Cache.Redis" />
 		<InternalsVisibleTo Include="Tharga.Cache.File" />
 		<InternalsVisibleTo Include="Tharga.Cache.Tests" />
+		<InternalsVisibleTo Include="Tharga.Cache.MongoDB.Tests" />
 		<InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
 	</ItemGroup>
 


### PR DESCRIPTION
Fixes #57.

## The bug

`DiskRepositoryCollectionBase<CacheEntity, string>` has no `DeleteOneAsync(TKey)` overload, so

```csharp
await collection.DeleteOneAsync(key.Value);
```

bound to `DeleteOneAsync(FilterDefinition<CacheEntity>)` through the driver's implicit
`string -> JsonFilterDefinition` conversion. It compiled cleanly, and then Mongo parsed the cache key
as a JSON filter document and threw on every drop:

```
System.FormatException: JSON reader was expecting a value but found 'FeedStatusDto'.
   at MongoDB.Bson.BsonDocument.Parse(String json)
   at MongoDB.Driver.JsonFilterDefinition`1.Render(RenderArgs`1 args)
   at Tharga.MongoDB.Disk.DiskRepositoryCollectionBase`2.DeleteOneAsync(FilterDefinition`1 filter, ...)
   at Tharga.Cache.MongoDB.MongoDB.DropAsync[T](Key key)
```

`CacheBase` prefixes every key with `typeof(T).Name`, so the first bareword in the message is the cached
type - which makes it read like a serialization problem, several layers away from the call that caused it.

From 0.4.1 onwards nothing backed by the MongoDB persist layer could be dropped or evicted.
`GetOneAsync` was unaffected because that id overload does exist, so reads kept working and the cache just
went permanently stale, silently. In our production this ran unnoticed for three months.

## The fix

Build the filter explicitly, at all three call sites:

- `DropAsync`
- the stale-entry delete in `GetAsync`
- `SetUpdateTime`, which backs `Invalidate` and `BuyMoreTime` - `UpdateOneAsync(key.Value, ...)` had the
  same latent misbinding (verified: passing `null` there is not ambiguous, so only the filter overload exists)

A key can now only be read as an id.

## Verified

Against a local MongoDB, a `SetAsync` + `DropAsync` round trip on `IEternalCache`:

| Version | Result |
|---|---|
| 0.4.0 | OK, entry dropped |
| 0.4.5 | `FormatException: JSON reader was expecting a value but found 'FeedStatusDto'` |
| 1.0.0 | same failure |
| this branch | OK, entry dropped |

## The test

`MongoDBKeyFilterTests` renders the `FilterDefinition` that reaches the collection and asserts it is an
`_id` equality. That is what tells an id apart from a parsed JSON document, and it needs no server - so it
runs on CI, where the `Integration` category is filtered out. On the old code the same test fails, because
rendering the `JsonFilterDefinition` throws.

`Tharga.Cache.MongoDB.Tests` needed `InternalsVisibleTo` from `Tharga.Cache` to construct the provider.

## Suggestion beyond this PR

Consider an id-typed `DeleteOneAsync(TKey id)` on `DiskRepositoryCollectionBase` in Tharga.MongoDB. As long
as it is missing, any `TKey` that happens to be `string` silently binds to the filter overload - the
compiler cannot help, and the failure surfaces far from its cause.
