### PR TITLE
chore(deps): tier 4 cascade — consume tiers 0-3, StackExchange.Redis 3.1.13

### DIFF
--- a/Sample/Tharga.Cache.Console/Tharga.Cache.Console.csproj
+++ b/Sample/Tharga.Cache.Console/Tharga.Cache.Console.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Tharga.Console" Version="4.2.0" />
+		<PackageReference Include="Tharga.Console" Version="4.2.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Tharga.Cache.Blazor/Tharga.Cache.Blazor.csproj
+++ b/Tharga.Cache.Blazor/Tharga.Cache.Blazor.csproj
@@ -37,7 +37,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Tharga.Blazor" Version="2.2.3" />
+    <PackageReference Include="Tharga.Blazor" Version="2.3.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Tharga.Cache\Tharga.Cache.csproj" />

--- a/Tharga.Cache.File.Tests/Tharga.Cache.File.Tests.csproj
+++ b/Tharga.Cache.File.Tests/Tharga.Cache.File.Tests.csproj
@@ -7,8 +7,8 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="8.10.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/Tharga.Cache.File/Tharga.Cache.File.csproj
+++ b/Tharga.Cache.File/Tharga.Cache.File.csproj
@@ -45,7 +45,7 @@
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.400">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Tharga.Cache.Mcp/Tharga.Cache.Mcp.csproj
+++ b/Tharga.Cache.Mcp/Tharga.Cache.Mcp.csproj
@@ -43,8 +43,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Tharga.Mcp" Version="1.0.0" />
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300">
+		<PackageReference Include="Tharga.Mcp" Version="1.1.0" />
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.400">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/Tharga.Cache.MongoDB.Tests/Tharga.Cache.MongoDB.Tests.csproj
+++ b/Tharga.Cache.MongoDB.Tests/Tharga.Cache.MongoDB.Tests.csproj
@@ -7,8 +7,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="8.10.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>

--- a/Tharga.Cache.MongoDB/Tharga.Cache.MongoDB.csproj
+++ b/Tharga.Cache.MongoDB/Tharga.Cache.MongoDB.csproj
@@ -45,11 +45,11 @@
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.400">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Tharga.MongoDB" Version="2.14.1" />
+    <PackageReference Include="Tharga.MongoDB" Version="2.14.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Tharga.Cache\Tharga.Cache.csproj" />

--- a/Tharga.Cache.Redis.Tests/Tharga.Cache.Redis.Tests.csproj
+++ b/Tharga.Cache.Redis.Tests/Tharga.Cache.Redis.Tests.csproj
@@ -9,8 +9,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="8.10.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>

--- a/Tharga.Cache.Redis/Tharga.Cache.Redis.csproj
+++ b/Tharga.Cache.Redis/Tharga.Cache.Redis.csproj
@@ -51,8 +51,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Polly" Version="8.7.0" />
-		<PackageReference Include="StackExchange.Redis" Version="3.0.7" />
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300">
+		<PackageReference Include="StackExchange.Redis" Version="3.1.13" />
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.400">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/Tharga.Cache.Tests/Tharga.Cache.Tests.csproj
+++ b/Tharga.Cache.Tests/Tharga.Cache.Tests.csproj
@@ -9,8 +9,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="8.10.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>

--- a/Tharga.Cache/Tharga.Cache.csproj
+++ b/Tharga.Cache/Tharga.Cache.csproj
@@ -53,8 +53,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="8.10.0" />
-		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300">
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.11" />
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.400">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>


### PR DESCRIPTION
**Tier 4** of the cascade update, and the last Toolkit repo in scope. Consumes everything below it.

## Internal — consuming tiers 0-3

| Package | From | To |
|---|---|---|
| `Tharga.Console` | 4.2.0 | **4.2.1** (Sample) |
| `Tharga.Blazor` | 2.2.3 | **2.3.0** — brings **Radzen.Blazor 11.x**, a major |
| `Tharga.Mcp` | 1.0.0 | **1.1.0** — brings MCP SDK 2.2.0 (stateless HTTP transport by default) |
| `Tharga.MongoDB` | 2.14.1 | **2.14.3** — brings MongoDB.Driver 3.11.0 |

All verified by an actual `dotnet restore`, not a flatcontainer listing. `Tharga.MongoDB` 2.14.3 needed a wait: flatcontainer listed it while restore still resolved 2.14.2 as newest.

Note the two behaviour-bearing ones. `Tharga.Cache.Blazor` picks up the Radzen major transitively, and `Tharga.Cache.Mcp` picks up the SDK's stateless-transport default. Both are why those packages shipped as minors rather than patches.

## External

**Library**
- `StackExchange.Redis` 3.0.7 → **3.1.13** (`Tharga.Cache.Redis`) — six patch levels
- `Microsoft.Extensions.Hosting.Abstractions` 10.0.9 → 10.0.11
- `Microsoft.SourceLink.GitHub` 10.0.300 → 10.0.400 (five projects; `PrivateAssets=all`, build-only)

`Polly` 8.7.0 is current and unchanged.

**Test tooling** (does not ship, all four test projects)
- `Microsoft.AspNetCore.Mvc.Testing` 10.0.9 → 10.0.11
- `Microsoft.NET.Test.Sdk` 18.7.0 → 18.9.0

## Verification — and a flaky suite, measured rather than assumed

`dotnet build -c Release --no-incremental` — **1 warning, 0 errors**. The warning is `CS0162` (unreachable code) in `Tharga.Cache.File/File.cs:63`, confirmed pre-existing by rebuilding that project without this change.

`dotnet test -c Release`:
- `Tharga.Cache.Tests` — 477/478, with **1-2 failures in `FetchDataThrottleTests`**
- `Tharga.Cache.Redis.Tests` — 5/5 passing
- `Tharga.Cache.File.Tests` — 2 skipped

**The throttle failures are pre-existing flakiness, and I measured that on clean master rather than assuming it.** Method: stashed every dependency change, rebuilt, and ran the filtered class four times on unmodified master. Result: **pass, fail, fail, fail** — it fails most runs with no changes at all.

The assertions are exact event counts under parallel load, so they lose races:

```
Expected dataGetEventCount to be greater than or equal to 8, but found 7.
Expected monitorGetEventCount to be 10, but found 9 (difference of -1).
```

Filed as a new Important/Medium backlog item. Not fixed here — this is a dependency PR — but worth flagging plainly: **a suite that fails most runs cannot answer "did my change break something?"**, and establishing that these bumps were innocent cost a four-run baseline.

## Left filed, deliberately

Both open issues are untouched, since this pass was scoped to dependencies:

- [#56](https://github.com/Tharga/Cache/issues/56) — FluentAssertions ships as a public dependency. **Confirmed genuine while here:** `FluentAssertions` 8.10.0 is referenced from `Tharga.Cache/Tharga.Cache.csproj`, the shipping library, not a test project — so its paid Xceed licence does propagate to consumers. Worth prioritising.
- [#55](https://github.com/Tharga/Cache/issues/55) — `AddCache` is not safe to call concurrently (static registration dictionary races).

No source changes, no public API change, no `MAJOR_MINOR` bump (stays 1.0).
