### PR TITLE
chore: bump version line to 1.1 for the FluentAssertions removal

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,10 @@ on:
     branches: [master]
 
 env:
-  MAJOR_MINOR: '1.0'
+  # Bumped 1.0 -> 1.1 for the gh#55/#56 release: Tharga.Cache no longer flows
+  # FluentAssertions to consumers, which is a compile-time break for anyone who
+  # was unknowingly relying on the transitive reference.
+  MAJOR_MINOR: '1.1'
 
 permissions:
   contents: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,9 +7,6 @@ on:
     branches: [master]
 
 env:
-  # Bumped 1.0 -> 1.1 for the gh#55/#56 release: Tharga.Cache no longer flows
-  # FluentAssertions to consumers, which is a compile-time break for anyone who
-  # was unknowingly relying on the transitive reference.
   MAJOR_MINOR: '1.1'
 
 permissions:


### PR DESCRIPTION
Sets `MAJOR_MINOR` to `1.1` so the gh#55/#56 release publishes as **1.1.0** rather than 1.0.3.

## Why a minor rather than a patch

#60 removed the FluentAssertions reference from `Tharga.Cache`. That is the right fix — the library never used it, and flowing it put the Xceed Community License on every consumer — but it is a **compile-time break for anyone who was unknowingly relying on the transitive reference**. That population is precisely the one that cannot anticipate the change, which is what makes a silent patch bump the wrong signal.

Secondary, smaller: #60 also changed the `AddCache` registration-accumulation semantics. Registrations no longer accumulate process-wide across service collections, and in a three-or-more-call sequence a call that does not mention a type now inherits the most recent value rather than the first-ever one.

## Effect

The version step reads `git tag -l "${MAJOR_MINOR}.*"`. No `1.1.*` tag exists, so `PATCH` starts at `0` and the next master release publishes **1.1.0**. The `1.0.x` tags are untouched.

## Sequencing

The release job for #60 is currently sitting at `waiting` on the gated deployment, so **nothing has published yet** — this lands before the approval, and the fixes then reach NuGet as 1.1.0 in a single release. Approving the older waiting run instead would mint 1.0.3 and make this moot.
