### PR TITLE
chore: use DOC_ROOT for requests path and drop the consumer-repo reference

### DIFF
--- a/.claude/mission.md
+++ b/.claude/mission.md
@@ -8,5 +8,5 @@ Caching library with MongoDB backend support, cache partitioning, and a Blazor m
 - **Shared instructions**: `$DOC_ROOT/Tharga/shared-instructions.md`
 - **Plan directory**: `$DOC_ROOT/Tharga/plans/Toolkit/Cache`
 - **Backlog**: `$DOC_ROOT/Tharga/Toolkit/Cache.md`
-- **Incoming requests**: `c:\Users\danie\SynologyDrive\Documents\Notes\Tharga\Requests.md` — check for pending requests for this project on startup
-- **Eplicta requests**: `$DEV_ROOT/Eplicta/plan/requests.md` — check for requests from Eplicta on startup
+- **Incoming requests**: `$DOC_ROOT/Tharga/Requests.md` — check for pending requests for this project on startup
+- **External requests**: open GitHub issues on this repository — consumers outside Tharga file there. This project does not read another product's files, and does not write status back to them.


### PR DESCRIPTION
Two corrections to `.claude/mission.md`.

## 1. `Incoming requests` was a literal path

```
- **Incoming requests**: `c:\Users\danie\SynologyDrive\Documents\Notes\Tharga\Requests.md`
+ **Incoming requests**: `$DOC_ROOT/Tharga/Requests.md`
```

Every other reference in this file already used `$DOC_ROOT`; this one line did not. A hard-coded path resolves on exactly one machine and silently finds nothing everywhere else — and "silently finds nothing" is indistinguishable from "nothing was pending", which is the failure mode that matters for a startup check.

## 2. The Eplicta reference is removed

```
- **Eplicta requests**: `$DEV_ROOT/Eplicta/plan/requests.md` — check for requests from Eplicta on startup
```

A Tharga project should not reference a consuming product's repository at all. External consumers file GitHub issues on this repo, and the outbound duty is a comment on that issue — not writing status back into their files.

This one was also already broken: the file it named does not exist, at that path or anywhere in the Eplicta checkout. Replaced with a line stating the actual channel, so the reference is not reintroduced later.

## Related

The same policy is now written into `shared-instructions.md` under *Feature Requests (cross-project) → External consumers*, and the "update any consuming project's request file" bullet in *Closing a feature* has been replaced by "comment on the GitHub issue".

Nine other Tharga sub-projects still carry one or both of these problems — reported separately, not touched here.