### PR TITLE
chore: remove multi-line comment blocks added in PR #60

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,8 +105,6 @@ jobs:
 
       - name: Test with coverage
         # Skip Integration (needs Mongo/Redis) and TimeCritical (wall-clock asserts) tests on shared CI runners.
-        # Microsoft.Testing.Platform (see global.json) — xunit.v3 4.x dropped the VSTest bridge, so the
-        # VSTest --filter expression and --collect:"XPlat Code Coverage" no longer apply here.
         run: dotnet test -c Release --no-build --filter-not-trait "Category=Integration" --filter-not-trait "Category=TimeCritical" --coverage --coverage-output-format cobertura --results-directory ./coverage
 
       - name: Upload coverage to Codecov

--- a/Tharga.Cache.Tests/AddCacheConcurrencyTests.cs
+++ b/Tharga.Cache.Tests/AddCacheConcurrencyTests.cs
@@ -12,8 +12,7 @@ public class AddCacheConcurrencyTests
 
     private sealed record Marker<T>;
 
-    // Nesting a generic in itself yields as many distinct cache types as needed without
-    // declaring one class per host.
+    // Nesting Marker in itself yields N distinct cache types without N declared classes.
     private static Type MarkerType(int depth)
     {
         var type = typeof(object);


### PR DESCRIPTION
Cleans up two multi-line inline comment blocks I introduced in #60, which break the Coding Guidelines: *single-line inline comments only, no multi-line inline comment blocks.*

## `.github/workflows/build.yml`

The `Test with coverage` step had a one-line comment already; I appended two more lines about the Microsoft.Testing.Platform migration, making it a three-line block. Those two lines are removed — the flags are self-describing and `global.json` declares the runner, so the explanation was history rather than something the file needs. The original single line about skipping Integration and TimeCritical tests stays.

## `Tharga.Cache.Tests/AddCacheConcurrencyTests.cs`

The note on `MarkerType` was two lines; reduced to one:

```csharp
// Nesting Marker in itself yields N distinct cache types without N declared classes.
```

This one earns its single line — the nested-generic trick is genuinely non-obvious from the code alone, which is exactly the case exception (b) exists for.

## Not touched

`build.yml` has three pre-existing multi-line blocks (the `Compute version`, `Resolve build version` and `Push to NuGet` steps). They predate my work, so removing them is a separate decision and not folded in here.

Comment-only changes; verified with a Release build and the CI-filtered suite: 467 tests, 465 passed, 2 skipped.