### PR TITLE
chore: version line to 1.1, comment cleanup, and mission.md request sources

### DIFF
--- a/.claude/mission.md
+++ b/.claude/mission.md
@@ -9,4 +9,3 @@ Caching library with MongoDB backend support, cache partitioning, and a Blazor m
 - **Plan directory**: `$DOC_ROOT/Tharga/plans/Toolkit/Cache`
 - **Backlog**: `$DOC_ROOT/Tharga/Toolkit/Cache.md`
 - **Incoming requests**: `$DOC_ROOT/Tharga/Requests.md` — check for pending requests for this project on startup
-- **External requests**: open GitHub issues on this repository — consumers outside Tharga file there. This project does not read another product's files, and does not write status back to them.

--- a/.claude/mission.md
+++ b/.claude/mission.md
@@ -8,5 +8,5 @@ Caching library with MongoDB backend support, cache partitioning, and a Blazor m
 - **Shared instructions**: `$DOC_ROOT/Tharga/shared-instructions.md`
 - **Plan directory**: `$DOC_ROOT/Tharga/plans/Toolkit/Cache`
 - **Backlog**: `$DOC_ROOT/Tharga/Toolkit/Cache.md`
-- **Incoming requests**: `c:\Users\danie\SynologyDrive\Documents\Notes\Tharga\Requests.md` — check for pending requests for this project on startup
-- **Eplicta requests**: `$DEV_ROOT/Eplicta/plan/requests.md` — check for requests from Eplicta on startup
+- **Incoming requests**: `$DOC_ROOT/Tharga/Requests.md` — check for pending requests for this project on startup
+- **External requests**: open GitHub issues on this repository — consumers outside Tharga file there. This project does not read another product's files, and does not write status back to them.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
     branches: [master]
 
 env:
-  MAJOR_MINOR: '1.0'
+  MAJOR_MINOR: '1.1'
 
 permissions:
   contents: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,8 +105,6 @@ jobs:
 
       - name: Test with coverage
         # Skip Integration (needs Mongo/Redis) and TimeCritical (wall-clock asserts) tests on shared CI runners.
-        # Microsoft.Testing.Platform (see global.json) — xunit.v3 4.x dropped the VSTest bridge, so the
-        # VSTest --filter expression and --collect:"XPlat Code Coverage" no longer apply here.
         run: dotnet test -c Release --no-build --filter-not-trait "Category=Integration" --filter-not-trait "Category=TimeCritical" --coverage --coverage-output-format cobertura --results-directory ./coverage
 
       - name: Upload coverage to Codecov

--- a/Tharga.Cache.Tests/AddCacheConcurrencyTests.cs
+++ b/Tharga.Cache.Tests/AddCacheConcurrencyTests.cs
@@ -12,8 +12,7 @@ public class AddCacheConcurrencyTests
 
     private sealed record Marker<T>;
 
-    // Nesting a generic in itself yields as many distinct cache types as needed without
-    // declaring one class per host.
+    // Nesting Marker in itself yields N distinct cache types without N declared classes.
     private static Type MarkerType(int depth)
     {
         var type = typeof(object);


### PR DESCRIPTION
Replaces #61, #62 and #63, which are closed in favour of this one. No library code changes — three project-level corrections, one commit each.

## 1. Version line 1.0 → 1.1

`MAJOR_MINOR: '1.1'` in `build.yml`. No `1.1.*` tag exists, so the counter starts clean and the next master release publishes **1.1.0**; the `1.0.x` tags are untouched. Verified on CI: `Computed version: 1.1.0 (previous: )`.

The reason is the registration-semantics change in #60, more than the dependency removal. `AddCache` registrations no longer accumulate process-wide across service collections, so a host that called `AddCache` on one collection and expected the types on another silently loses that — a behavioural change with no compile error to warn anyone. In a three-or-more-call sequence, a call that doesn't mention a type now inherits the most recent value rather than the first-ever one.

The FluentAssertions removal is the weaker half of the argument: it can break a consumer who was unknowingly compiling against the transitive reference, but #56 shows consumers were *fighting* the dependency (`NU1605` from pinning an older version), not relying on it.

**This is the one change here with externally visible effect** — it sets the version every consumer sees.

## 2. Remove multi-line comment blocks added in #60

Coding Guidelines allow single-line inline comments only, no multi-line blocks. Two of mine broke that:

- **`build.yml`, `Test with coverage`** — I appended two lines about the Microsoft.Testing.Platform migration to an existing one-line comment, making a three-line block. Removed; the flags are self-describing and `global.json` declares the runner, so it was history rather than something the file needs. The original line about skipping Integration and TimeCritical tests stays.
- **`AddCacheConcurrencyTests.cs`** — the note on `MarkerType` was two lines, now one. This one earns its single line: the nested-generic trick genuinely isn't readable from the code.

Not touched: `build.yml` has three pre-existing multi-line blocks (`Compute version`, `Resolve build version`, `Push to NuGet`). They predate this work, so removing them is a separate decision.

## 3. `.claude/mission.md` request sources

Two corrections to agent instructions — no build or runtime effect.

- **`Incoming requests`** used a literal `c:\Users\...` path while every other reference in the file already used `$DOC_ROOT`. A hard-coded path resolves on one machine and silently finds nothing elsewhere — indistinguishable from "nothing was pending", which is the failure mode that matters for a startup check.
- **The Eplicta reference is removed.** A Tharga project should not reference a consuming product's repository; external consumers file GitHub issues here, and the outbound duty is a comment on the issue rather than writing status into their files. That reference was also already broken — the file it named does not exist, at that path or anywhere in the Eplicta checkout. Replaced with a line stating the actual channel so it is not reintroduced.

## Verification

Release build clean. CI-filtered suite: **467 tests, 465 passed, 2 skipped**.

Note the suite contains two known timing-flaky tests, tracked as backlog items 9 and 13. Item 13 (`TimeToLiveCacheTests.DropEvenIfUsed`) carries no `TimeCritical` trait, so unlike item 9 it is not filtered out of CI and can redden this PR at random. If a run fails on that test, it is not this change.
