### PR TITLE
chore: cascade nuget sweep (tier 4) + release retry guard

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -213,11 +213,29 @@ jobs:
           if [ -n "${{ steps.version.outputs.previous_tag }}" ]; then
             NOTES_FLAG="--notes-start-tag ${{ steps.version.outputs.previous_tag }}"
           fi
-          gh release create "${{ steps.version.outputs.version }}" \
-            --title "v${{ steps.version.outputs.version }}" \
-            --generate-notes \
-            $NOTES_FLAG \
-            ./artifacts/*.nupkg
+          # The package is already on nuget.org by this point, so a transient GitHub API failure here
+          # leaves a published package with no tag. The next build then recomputes the SAME version,
+          # pushes a duplicate that --skip-duplicate swallows silently, and the version after it never
+          # ships. Observed three times on 2026-08-17 during a GitHub incident (HTTP 503/504).
+          # Retry, and treat an already-created release as success so a re-run is safe.
+          for attempt in 1 2 3 4 5; do
+            if gh release create "${{ steps.version.outputs.version }}" \
+                 --title "v${{ steps.version.outputs.version }}" \
+                 --generate-notes \
+                 $NOTES_FLAG \
+                 ./artifacts/*.nupkg; then
+              echo "Release ${{ steps.version.outputs.version }} created."
+              exit 0
+            fi
+            if gh release view "${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+              echo "Release ${{ steps.version.outputs.version }} already exists - an earlier attempt succeeded."
+              exit 0
+            fi
+            echo "Attempt $attempt failed; retrying in 20s..."
+            sleep 20
+          done
+          echo "::error::Could not create the GitHub release for ${{ steps.version.outputs.version }} after 5 attempts. The package is most likely already on nuget.org, so the tag must be created by hand or the next release will silently republish this version: git tag ${{ steps.version.outputs.version }} <sha> && git push origin ${{ steps.version.outputs.version }}"
+          exit 1
 
       - name: Comment released version on merged PR
         if: always()
@@ -298,11 +316,26 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create "${{ steps.version.outputs.version }}" \
-            --title "v${{ steps.version.outputs.version }} (pre-release)" \
-            --notes "Pre-release from \`${{ github.head_ref }}\` branch." \
-            --prerelease \
-            ./artifacts/*.nupkg
+          # Same reasoning as the release job: the pre-release package is pushed before this runs, so a
+          # transient API failure would leave it published with no tag to match.
+          for attempt in 1 2 3 4 5; do
+            if gh release create "${{ steps.version.outputs.version }}" \
+                 --title "v${{ steps.version.outputs.version }} (pre-release)" \
+                 --notes "Pre-release from \`${{ github.head_ref }}\` branch." \
+                 --prerelease \
+                 ./artifacts/*.nupkg; then
+              echo "Pre-release ${{ steps.version.outputs.version }} created."
+              exit 0
+            fi
+            if gh release view "${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+              echo "Pre-release ${{ steps.version.outputs.version }} already exists - an earlier attempt succeeded."
+              exit 0
+            fi
+            echo "Attempt $attempt failed; retrying in 20s..."
+            sleep 20
+          done
+          echo "::error::Could not create the GitHub pre-release for ${{ steps.version.outputs.version }} after 5 attempts."
+          exit 1
 
   docs:
     needs: release

--- a/Sample/Tharga.Cache.Console/Tharga.Cache.Console.csproj
+++ b/Sample/Tharga.Cache.Console/Tharga.Cache.Console.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Tharga.Console" Version="4.2.1" />
+		<PackageReference Include="Tharga.Console" Version="4.2.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Tharga.Cache.Blazor/Tharga.Cache.Blazor.csproj
+++ b/Tharga.Cache.Blazor/Tharga.Cache.Blazor.csproj
@@ -37,7 +37,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Tharga.Blazor" Version="2.3.1" />
+    <PackageReference Include="Tharga.Blazor" Version="2.3.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Tharga.Cache\Tharga.Cache.csproj" />

--- a/Tharga.Cache.Mcp/Tharga.Cache.Mcp.csproj
+++ b/Tharga.Cache.Mcp/Tharga.Cache.Mcp.csproj
@@ -43,7 +43,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Tharga.Mcp" Version="1.1.0" />
+		<PackageReference Include="Tharga.Mcp" Version="2.0.0" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.400">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Tharga.Cache.MongoDB/Tharga.Cache.MongoDB.csproj
+++ b/Tharga.Cache.MongoDB/Tharga.Cache.MongoDB.csproj
@@ -49,7 +49,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Tharga.MongoDB" Version="2.14.3" />
+    <PackageReference Include="Tharga.MongoDB" Version="2.15.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Tharga.Cache\Tharga.Cache.csproj" />


### PR DESCRIPTION
Final tier of the cascade sweep. Internal bumps to the versions published earlier in this sweep: Console 4.2.2, Blazor 2.3.2, Mcp 2.0.0, MongoDB 2.15.0.

Mcp 2.0.0 drops `IMcpContext.IsDeveloper`; Cache only ever takes `IMcpContext` as a parameter, so no code changed.

Also adds the release retry guard — the package reaches nuget.org before `gh release create` runs, so a transient API failure strands a published version with no tag and the next build silently republishes it.

Tests: 467 pass, 0 fail (Integration and TimeCritical excluded, same filters as CI).

Publishes as **1.1.0**, carrying the AddCache race and FluentAssertions fixes already on this line.